### PR TITLE
[SO-52] feat: 플래너, 예비부부 회원가입 api 추가

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,12 +6,10 @@
   <component name="ChangeListManager">
     <list default="true" id="6731f480-c7cd-43bb-9ac8-952384607021" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/entity/PortfolioTag.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/entity/PortfolioTag.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/service/PortfolioService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/service/PortfolioService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/tag/dto/TagMapper.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/tag/dto/TagMapper.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Users.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Users.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/repository/UsersRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/repository/UsersRepository.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/resources/application-dev.yml" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/application-dev.yml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Planner.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Planner.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/mapper/CustomerMapper.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/mapper/CustomerMapper.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/mapper/PlannerMapper.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/mapper/PlannerMapper.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/service/UsersService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/service/UsersService.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -53,24 +51,24 @@
     <option name="showLibraryContents" value="true" />
     <option name="showMembers" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "RequestMappingsPanelOrder0": "0",
-    "RequestMappingsPanelOrder1": "1",
-    "RequestMappingsPanelWidth0": "75",
-    "RequestMappingsPanelWidth1": "75",
-    "WebServerToolWindowFactoryState": "false",
-    "node.js.detected.package.eslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "project.structure.last.edited": "Project",
-    "project.structure.proportion": "0.0",
-    "project.structure.side.proportion": "0.0",
-    "settings.editor.selected.configurable": "reference.settingsdialog.project.gradle",
-    "spring.configuration.checksum": "49fd28e25dc049ffa2a12e82456c0593",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RequestMappingsPanelOrder0&quot;: &quot;0&quot;,
+    &quot;RequestMappingsPanelOrder1&quot;: &quot;1&quot;,
+    &quot;RequestMappingsPanelWidth0&quot;: &quot;75&quot;,
+    &quot;RequestMappingsPanelWidth1&quot;: &quot;75&quot;,
+    &quot;WebServerToolWindowFactoryState&quot;: &quot;false&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;project.structure.last.edited&quot;: &quot;Project&quot;,
+    &quot;project.structure.proportion&quot;: &quot;0.0&quot;,
+    &quot;project.structure.side.proportion&quot;: &quot;0.0&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;reference.settingsdialog.project.gradle&quot;,
+    &quot;spring.configuration.checksum&quot;: &quot;49fd28e25dc049ffa2a12e82456c0593&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="RunManager">
     <configuration name="WeddingmateApplication" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
       <module name="weddingmate.main" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,8 +5,13 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6731f480-c7cd-43bb-9ac8-952384607021" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.gitignore" beforeDir="false" afterPath="$PROJECT_DIR$/.gitignore" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/entity/PortfolioTag.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/entity/PortfolioTag.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/service/PortfolioService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/service/PortfolioService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/tag/dto/TagMapper.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/tag/dto/TagMapper.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Users.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Users.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/repository/UsersRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/repository/UsersRepository.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/resources/application-dev.yml" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/application-dev.yml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -18,8 +23,21 @@
       <ProjectState />
     </projectState>
   </component>
+  <component name="FileTemplateManagerImpl">
+    <option name="RECENT_TEMPLATES">
+      <list>
+        <option value="package-info" />
+        <option value="Interface" />
+        <option value="Enum" />
+        <option value="Class" />
+      </list>
+    </option>
+  </component>
   <component name="Git.Settings">
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="JpbToolWindowState">
+    <option name="isToolWindowVisible" value="false" />
   </component>
   <component name="MarkdownSettingsMigration">
     <option name="stateVersion" value="1" />
@@ -45,6 +63,10 @@
     "node.js.detected.package.eslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "node.js.selected.package.tslint": "(autodetect)",
+    "project.structure.last.edited": "Project",
+    "project.structure.proportion": "0.0",
+    "project.structure.side.proportion": "0.0",
+    "settings.editor.selected.configurable": "reference.settingsdialog.project.gradle",
     "spring.configuration.checksum": "49fd28e25dc049ffa2a12e82456c0593",
     "vue.rearranger.settings.migration": "true"
   }
@@ -70,6 +92,8 @@
       <workItem from="1687964071174" duration="4260000" />
       <workItem from="1687971741491" duration="3755000" />
       <workItem from="1689660277402" duration="654000" />
+      <workItem from="1690361146351" duration="18388000" />
+      <workItem from="1690381273037" duration="4356000" />
     </task>
     <servers />
   </component>

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/category/CategoryEnum.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/category/CategoryEnum.java
@@ -1,0 +1,12 @@
+package swmaestro.spaceodyssey.weddingmate.domain.category;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum CategoryEnum {
+	PLANNER("플래너"), PORTFOLIO("분위기");
+
+	private String value;
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/dto/PortfolioTagMapper.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/dto/PortfolioTagMapper.java
@@ -1,0 +1,21 @@
+package swmaestro.spaceodyssey.weddingmate.domain.portfolio.dto;
+
+import org.springframework.stereotype.Component;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import swmaestro.spaceodyssey.weddingmate.domain.portfolio.entity.PortfolioTag;
+import swmaestro.spaceodyssey.weddingmate.domain.tag.entity.Tag;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Customer;
+
+@Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class PortfolioTagMapper {
+
+	public PortfolioTag customerToEntity(Customer customer, Tag tag) {
+		return PortfolioTag.customerBuilder()
+			.customer(customer)
+			.tag(tag)
+			.build();
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/entity/PortfolioTag.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/entity/PortfolioTag.java
@@ -1,6 +1,7 @@
 package swmaestro.spaceodyssey.weddingmate.domain.portfolio.entity;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -10,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import swmaestro.spaceodyssey.weddingmate.domain.tag.entity.Tag;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Customer;
 
 @Entity
 @Getter
@@ -23,13 +25,23 @@ public class PortfolioTag {
 	@JoinColumn
 	private Portfolio portfolio;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn
+	private Customer customer;
+
 	@ManyToOne
 	@JoinColumn
 	private Tag tag;
 
-	@Builder
+	@Builder(builderMethodName = "portfolioBuilder")
 	public PortfolioTag(Portfolio portfolio, Tag tag) {
 		this.portfolio = portfolio;
+		this.tag = tag;
+	}
+
+	@Builder(builderMethodName = "customerBuilder")
+	public PortfolioTag(Customer customer, Tag tag) {
+		this.customer = customer;
 		this.tag = tag;
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/service/PortfolioService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import swmaestro.spaceodyssey.weddingmate.domain.category.CategoryEnum;
 import swmaestro.spaceodyssey.weddingmate.domain.category.dto.CategoryMapper;
 import swmaestro.spaceodyssey.weddingmate.domain.item.dto.ItemMapper;
 import swmaestro.spaceodyssey.weddingmate.domain.item.dto.ItemResDto;
@@ -51,7 +52,8 @@ public class PortfolioService {
 			.build();
 
 		portfolioSaveReqDto.getTags().forEach(portfolioTag -> {
-			Tag tag = this.tagMapper.contentToEntity(portfolioTag, categoryMapper.findCategoryByContentOrElseCreate("분위기"));
+			Tag tag = this.tagMapper.contentToEntity(portfolioTag,
+				categoryMapper.findCategoryByContentOrElseCreate(CategoryEnum.PORTFOLIO.name()));
 			tagList.add(new PortfolioTag(portfolio, tag));
 		});
 
@@ -115,7 +117,7 @@ public class PortfolioService {
 		portfolioRepository.save(portfolio);
 
 		List<Integer> orderList = portfolioUpdateReqDto.getOrderList();
-		List <Long> itemList = portfolioUpdateReqDto.getItemList();
+		List<Long> itemList = portfolioUpdateReqDto.getItemList();
 
 		for (int i = 0; i < orderList.size(); i++) {
 			Item item = itemRepository.findById(itemList.get(i))

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/tag/dto/TagMapper.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/tag/dto/TagMapper.java
@@ -1,6 +1,7 @@
 package swmaestro.spaceodyssey.weddingmate.domain.tag.dto;
 
 import java.util.Optional;
+import java.util.List;
 
 import org.springframework.stereotype.Component;
 
@@ -14,16 +15,16 @@ import swmaestro.spaceodyssey.weddingmate.domain.tag.repository.TagRepository;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class TagMapper {
 	private final TagRepository tagRepository;
+
 	public Tag contentToEntity(String keyword, Category category) {
-		Optional<Tag> tagOptional = tagRepository.findByContent(keyword);
-
-		if (tagOptional.isEmpty()) {
-			Tag tag = Tag.builder().content(keyword).category(category).isDefault(false).build();
-			tagRepository.save(tag);
-
-			return tag;
-		}
-		return tagOptional.get();
+		return tagRepository.findByContent(keyword)
+			.orElseGet(() -> tagRepository.save(
+				Tag.builder()
+					.content(keyword)
+					.category(category)
+					.isDefault(false)
+					.build()
+			));
 	}
 
 	public TagResDto entityToDto(Tag tag) {

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/tag/entity/Tag.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/tag/entity/Tag.java
@@ -17,6 +17,7 @@ import lombok.NoArgsConstructor;
 import swmaestro.spaceodyssey.weddingmate.domain.category.entity.Category;
 import swmaestro.spaceodyssey.weddingmate.domain.item.entity.ItemTag;
 import swmaestro.spaceodyssey.weddingmate.domain.portfolio.entity.PortfolioTag;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.PlannerTag;
 import swmaestro.spaceodyssey.weddingmate.global.entity.BaseTimeEntity;
 
 @NoArgsConstructor
@@ -44,10 +45,21 @@ public class Tag extends BaseTimeEntity {
 	@OneToMany(mappedBy = "tag")
 	private List<PortfolioTag> portfolioTagList;
 
+	@OneToMany(mappedBy = "tag")
+	private List<PlannerTag> plannerTagList;
+
 	@Builder
 	public Tag(String content, Category category, Boolean isDefault) {
 		this.content = content;
 		this.category = category;
 		this.isDefault = isDefault;
+	}
+
+	@Builder
+	public Tag(String content, Category category, List<ItemTag> itemTagList, List<PortfolioTag> portfolioTagList) {
+		this.content = content;
+		this.category = category;
+		this.itemTagList = itemTagList;
+		this.portfolioTagList = portfolioTagList;
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/controller/SignupController.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/controller/SignupController.java
@@ -1,0 +1,55 @@
+package swmaestro.spaceodyssey.weddingmate.domain.users.controller;
+
+import static swmaestro.spaceodyssey.weddingmate.global.constant.ResponseConstant.*;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import swmaestro.spaceodyssey.weddingmate.domain.users.dto.CustomerSignupReqDto;
+import swmaestro.spaceodyssey.weddingmate.domain.users.dto.PlannerSignupReqDto;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.AuthUsers;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
+import swmaestro.spaceodyssey.weddingmate.domain.users.repository.UsersRepository;
+import swmaestro.spaceodyssey.weddingmate.domain.users.service.UsersService;
+import swmaestro.spaceodyssey.weddingmate.global.exception.users.UserNotFoundException;
+
+@RestController
+@RequestMapping("/api/v1/signup")
+@RequiredArgsConstructor
+public class SignupController {
+
+	private final UsersService usersService;
+	private final UsersRepository usersRepository;
+
+	@PostMapping("/planner")
+	@ResponseStatus(value = HttpStatus.CREATED)
+	public ResponseEntity<String> plannerSignup(@AuthUsers Users users, @RequestBody PlannerSignupReqDto reqDto) {
+		usersService.signupPlanner(users, reqDto);
+		return ResponseEntity.ok().body(reqDto.getNickname() + PLANNER_SIGNUP_SUCCESS);
+	}
+
+	@PostMapping("/customer")
+	@ResponseStatus(value = HttpStatus.CREATED)
+	public ResponseEntity<String> customerSignup(@AuthUsers Users users, @RequestBody CustomerSignupReqDto reqDto) {
+		usersService.signupCustomer(users, reqDto);
+		return ResponseEntity.ok().body(reqDto.getNickname() + CUSTOMER_SIGNUP_SUCCESS);
+	}
+
+	@GetMapping("/")
+	public ResponseEntity<String> test(@AuthUsers Users users){
+		Users pUsers = usersRepository.findByEmail(users.getEmail())
+			.orElseThrow(UserNotFoundException::new);
+		pUsers.updateNickname("테스트닉네임");
+
+		Users nUsers = usersRepository.findByNickname(pUsers.getNickname())
+			.orElseThrow(UserNotFoundException::new);
+		return ResponseEntity.ok().body(nUsers.getEmail() + ' ' + nUsers.getNickname());
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/controller/SignupController.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/controller/SignupController.java
@@ -4,7 +4,6 @@ import static swmaestro.spaceodyssey.weddingmate.global.constant.ResponseConstan
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,9 +15,7 @@ import swmaestro.spaceodyssey.weddingmate.domain.users.dto.CustomerSignupReqDto;
 import swmaestro.spaceodyssey.weddingmate.domain.users.dto.PlannerSignupReqDto;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.AuthUsers;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
-import swmaestro.spaceodyssey.weddingmate.domain.users.repository.UsersRepository;
 import swmaestro.spaceodyssey.weddingmate.domain.users.service.UsersService;
-import swmaestro.spaceodyssey.weddingmate.global.exception.users.UserNotFoundException;
 
 @RestController
 @RequestMapping("/api/v1/signup")
@@ -26,7 +23,6 @@ import swmaestro.spaceodyssey.weddingmate.global.exception.users.UserNotFoundExc
 public class SignupController {
 
 	private final UsersService usersService;
-	private final UsersRepository usersRepository;
 
 	@PostMapping("/planner")
 	@ResponseStatus(value = HttpStatus.CREATED)
@@ -40,16 +36,5 @@ public class SignupController {
 	public ResponseEntity<String> customerSignup(@AuthUsers Users users, @RequestBody CustomerSignupReqDto reqDto) {
 		usersService.signupCustomer(users, reqDto);
 		return ResponseEntity.ok().body(reqDto.getNickname() + CUSTOMER_SIGNUP_SUCCESS);
-	}
-
-	@GetMapping("/")
-	public ResponseEntity<String> test(@AuthUsers Users users){
-		Users pUsers = usersRepository.findByEmail(users.getEmail())
-			.orElseThrow(UserNotFoundException::new);
-		pUsers.updateNickname("테스트닉네임");
-
-		Users nUsers = usersRepository.findByNickname(pUsers.getNickname())
-			.orElseThrow(UserNotFoundException::new);
-		return ResponseEntity.ok().body(nUsers.getEmail() + ' ' + nUsers.getNickname());
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/dto/CustomerSignupReqDto.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/dto/CustomerSignupReqDto.java
@@ -1,0 +1,16 @@
+package swmaestro.spaceodyssey.weddingmate.domain.users.dto;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CustomerSignupReqDto {
+	String nickname;
+	String weddingDate;
+	String budget;
+	List<String> portfolioTagList;
+	List<String> plannerTagList;
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/dto/PlannerSignupReqDto.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/dto/PlannerSignupReqDto.java
@@ -1,0 +1,16 @@
+package swmaestro.spaceodyssey.weddingmate.domain.users.dto;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PlannerSignupReqDto {
+	String nickname;
+	String company;
+	String position;
+	String region;
+	List<String> plannerTagList;
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Customer.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Customer.java
@@ -1,0 +1,62 @@
+package swmaestro.spaceodyssey.weddingmate.domain.users.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import swmaestro.spaceodyssey.weddingmate.domain.portfolio.entity.PortfolioTag;
+import swmaestro.spaceodyssey.weddingmate.global.entity.BaseTimeEntity;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Customer extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long customerId;
+
+	@OneToOne(mappedBy = "customer")
+	private Users users;
+
+	private String weddingDate;
+
+	@NotNull(message = "예산은 필수로 입력되어야 합니다.")
+	private String budget;
+
+	@OneToMany(mappedBy = "customer", cascade = CascadeType.PERSIST)
+	private List<PortfolioTag> portfolioTagList = new ArrayList<>();
+
+	@OneToMany(mappedBy = "customer", cascade = CascadeType.PERSIST)
+	private List<PlannerTag> plannerTagList = new ArrayList<>();
+
+	@Builder
+	public Customer(String weddingDate, String budget) {
+		this.weddingDate = weddingDate;
+		this.budget = budget;
+	}
+
+	public void setUsers(Users users) {
+		this.users = users;
+		users.setCustomer(this);
+	}
+
+	public void createPortfolioTagList(List<PortfolioTag> portfolioTagList) {
+		this.portfolioTagList = portfolioTagList;
+	}
+
+	public void createPlannerTagList(List<PlannerTag> plannerTagList) {
+		this.plannerTagList = plannerTagList;
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Planner.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Planner.java
@@ -52,6 +52,7 @@ public class Planner extends BaseTimeEntity {
 		this.users = users;
 		users.setPlanner(this);
 	}
+
 	public void createPlannerTagList(List<PlannerTag> plannerTagList) {
 		this.plannerTagList = plannerTagList;
 	}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Planner.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Planner.java
@@ -1,0 +1,58 @@
+package swmaestro.spaceodyssey.weddingmate.domain.users.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import swmaestro.spaceodyssey.weddingmate.global.entity.BaseTimeEntity;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Planner extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long plannerId;
+
+	@OneToOne(mappedBy = "planner")
+	private Users users;
+
+	@NotNull(message = "소속은 필수로 입력되어야 합니다.")
+	private String company;
+
+	@NotNull(message = "직급은 필수로 입력되어야 합니다.")
+	private String position;
+
+	@NotNull(message = "지역은 필수로 입력되어야 합니다.")
+	private String region;
+
+	@OneToMany(mappedBy = "planner", cascade = CascadeType.PERSIST)
+	private List<PlannerTag> plannerTagList = new ArrayList<>();
+
+	@Builder
+	public Planner(String company, String position, String region) {
+		this.company = company;
+		this.position = position;
+		this.region = region;
+	}
+
+	public void setUsers(Users users) {
+		this.users = users;
+		users.setPlanner(this);
+	}
+	public void createPlannerTagList(List<PlannerTag> plannerTagList) {
+		this.plannerTagList = plannerTagList;
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/PlannerTag.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/PlannerTag.java
@@ -1,0 +1,47 @@
+package swmaestro.spaceodyssey.weddingmate.domain.users.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import swmaestro.spaceodyssey.weddingmate.domain.tag.entity.Tag;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class PlannerTag {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long plannerTagId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn
+	private Planner planner;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn
+	private Customer customer;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn
+	private Tag tag;
+
+	@Builder(builderMethodName = "plannerBuilder")
+	public PlannerTag(Planner planner, Tag tag) {
+		this.planner = planner;
+		this.tag = tag;
+	}
+
+	@Builder(builderMethodName = "customerBuilder")
+	public PlannerTag(Customer customer, Tag tag) {
+		this.customer = customer;
+		this.tag = tag;
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Users.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Users.java
@@ -7,12 +7,16 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,7 +27,7 @@ import swmaestro.spaceodyssey.weddingmate.domain.users.enums.UserEnum;
 import swmaestro.spaceodyssey.weddingmate.global.entity.BaseTimeEntity;
 
 @SuppressWarnings("checkstyle:RegexpMultiline")
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
 public class Users extends BaseTimeEntity {
@@ -62,6 +66,14 @@ public class Users extends BaseTimeEntity {
 	@Column(nullable = false)
 	private Integer reportCnt = 0;
 
+	@OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+	@JoinColumn(name = "planner_id")
+	private Planner planner;
+
+	@OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+	@JoinColumn(name = "customer_id")
+	private Customer customer;
+
 	@OneToMany(mappedBy = "users", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Portfolio> portfolioList;
 
@@ -83,5 +95,29 @@ public class Users extends BaseTimeEntity {
 		this.authProviderId = oAuth2UserInfo.getOAuth2Id();
 
 		return this;
+	}
+
+	public void setPlanner(Planner planner) {
+		this.planner = planner;
+
+		if (planner.getUsers() != this) {
+			planner.setUsers(this);
+		}
+	}
+
+	public void setCustomer(Customer customer) {
+		this.customer = customer;
+
+		if (customer.getUsers() != this) {
+			customer.setUsers(this);
+		}
+	}
+
+	public void updateNickname(String nickname) {
+		this.nickname = nickname;
+	}
+
+	public void createPhone(String phone) {
+		this.phone = phone;
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/mapper/CustomerMapper.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/mapper/CustomerMapper.java
@@ -1,0 +1,72 @@
+package swmaestro.spaceodyssey.weddingmate.domain.users.mapper;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.stereotype.Component;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import swmaestro.spaceodyssey.weddingmate.domain.category.CategoryEnum;
+import swmaestro.spaceodyssey.weddingmate.domain.category.dto.CategoryMapper;
+import swmaestro.spaceodyssey.weddingmate.domain.category.entity.Category;
+import swmaestro.spaceodyssey.weddingmate.domain.portfolio.dto.PortfolioTagMapper;
+import swmaestro.spaceodyssey.weddingmate.domain.portfolio.entity.PortfolioTag;
+import swmaestro.spaceodyssey.weddingmate.domain.tag.dto.TagMapper;
+import swmaestro.spaceodyssey.weddingmate.domain.tag.entity.Tag;
+import swmaestro.spaceodyssey.weddingmate.domain.users.dto.CustomerSignupReqDto;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Customer;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.PlannerTag;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
+
+@Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class CustomerMapper {
+	private final CategoryMapper categoryMapper;
+	private final TagMapper tagMapper;
+	private final PortfolioTagMapper portfolioTagMapper;
+	private final PlannerTagMapper plannerTagMapper;
+
+	public Customer toEntity(Users users, CustomerSignupReqDto reqDto) {
+		Customer customer = Customer.builder()
+			.weddingDate(reqDto.getWeddingDate())
+			.budget(reqDto.getBudget())
+			.build();
+		customer.setUsers(users);
+		System.out.println("customer 1차 생성 완");
+		// 1) 유저가 원하는 분위기 태그
+		List<PortfolioTag> portfolioTagList = getPortfolioTagList(customer, reqDto.getPortfolioTagList());
+		System.out.println("portfolio tag 생성 완");
+		List<PlannerTag> plannerTagList = getPlannerTagList(customer, reqDto.getPlannerTagList());
+		System.out.println("planner tag list 생성 완");
+
+		customer.createPortfolioTagList(portfolioTagList);
+		customer.createPlannerTagList(plannerTagList);
+
+		return customer;
+	}
+
+	public List<PortfolioTag> getPortfolioTagList(Customer customer, List<String> portfolioTagListReqDtO) {
+		Category portfolioCategory = categoryMapper.findCategoryByContentOrElseCreate(CategoryEnum.PORTFOLIO.name());
+		List<Tag> tagList = portfolioTagListReqDtO
+			.stream().filter(Objects::nonNull)
+			.map(content -> tagMapper.contentToEntity(content, portfolioCategory))
+			.toList();
+		return tagList
+			.stream().filter(Objects::nonNull)
+			.map(tag -> portfolioTagMapper.customerToEntity(customer, tag))
+			.toList();
+	}
+
+	public List<PlannerTag> getPlannerTagList(Customer customer, List<String> plannerTagListReqDto) {
+		Category portfolioCategory = categoryMapper.findCategoryByContentOrElseCreate(CategoryEnum.PLANNER.name());
+		List<Tag> tagList = plannerTagListReqDto
+			.stream().filter(Objects::nonNull)
+			.map(content -> tagMapper.contentToEntity(content, portfolioCategory))
+			.toList();
+		return tagList
+			.stream().filter(Objects::nonNull)
+			.map(tag -> plannerTagMapper.customerToEntity(customer, tag))
+			.toList();
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/mapper/CustomerMapper.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/mapper/CustomerMapper.java
@@ -17,7 +17,6 @@ import swmaestro.spaceodyssey.weddingmate.domain.tag.entity.Tag;
 import swmaestro.spaceodyssey.weddingmate.domain.users.dto.CustomerSignupReqDto;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Customer;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.PlannerTag;
-import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
 
 @Component
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
@@ -27,18 +26,14 @@ public class CustomerMapper {
 	private final PortfolioTagMapper portfolioTagMapper;
 	private final PlannerTagMapper plannerTagMapper;
 
-	public Customer toEntity(Users users, CustomerSignupReqDto reqDto) {
+	public Customer toEntity(CustomerSignupReqDto reqDto) {
 		Customer customer = Customer.builder()
 			.weddingDate(reqDto.getWeddingDate())
 			.budget(reqDto.getBudget())
 			.build();
-		customer.setUsers(users);
-		System.out.println("customer 1차 생성 완");
-		// 1) 유저가 원하는 분위기 태그
+
 		List<PortfolioTag> portfolioTagList = getPortfolioTagList(customer, reqDto.getPortfolioTagList());
-		System.out.println("portfolio tag 생성 완");
 		List<PlannerTag> plannerTagList = getPlannerTagList(customer, reqDto.getPlannerTagList());
-		System.out.println("planner tag list 생성 완");
 
 		customer.createPortfolioTagList(portfolioTagList);
 		customer.createPlannerTagList(plannerTagList);

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/mapper/PlannerMapper.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/mapper/PlannerMapper.java
@@ -15,7 +15,6 @@ import swmaestro.spaceodyssey.weddingmate.domain.tag.entity.Tag;
 import swmaestro.spaceodyssey.weddingmate.domain.users.dto.PlannerSignupReqDto;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Planner;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.PlannerTag;
-import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
 
 @Component
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,13 +23,12 @@ public class PlannerMapper {
 	private final TagMapper tagMapper;
 	private final PlannerTagMapper plannerTagMapper;
 
-	public Planner toEntity(Users users, PlannerSignupReqDto reqDto) {
+	public Planner toEntity(PlannerSignupReqDto reqDto) {
 		Planner planner = Planner.builder()
 			.company(reqDto.getCompany())
 			.position(reqDto.getPosition())
 			.region(reqDto.getRegion())
 			.build();
-		planner.setUsers(users);
 
 		Category category = categoryMapper.findCategoryByContentOrElseCreate(CategoryEnum.PLANNER.name());
 		List<Tag> tagList = reqDto.getPlannerTagList()

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/mapper/PlannerMapper.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/mapper/PlannerMapper.java
@@ -1,0 +1,48 @@
+package swmaestro.spaceodyssey.weddingmate.domain.users.mapper;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.stereotype.Component;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import swmaestro.spaceodyssey.weddingmate.domain.category.CategoryEnum;
+import swmaestro.spaceodyssey.weddingmate.domain.category.dto.CategoryMapper;
+import swmaestro.spaceodyssey.weddingmate.domain.category.entity.Category;
+import swmaestro.spaceodyssey.weddingmate.domain.tag.dto.TagMapper;
+import swmaestro.spaceodyssey.weddingmate.domain.tag.entity.Tag;
+import swmaestro.spaceodyssey.weddingmate.domain.users.dto.PlannerSignupReqDto;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Planner;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.PlannerTag;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
+
+@Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlannerMapper {
+	private final CategoryMapper categoryMapper;
+	private final TagMapper tagMapper;
+	private final PlannerTagMapper plannerTagMapper;
+
+	public Planner toEntity(Users users, PlannerSignupReqDto reqDto) {
+		Planner planner = Planner.builder()
+			.company(reqDto.getCompany())
+			.position(reqDto.getPosition())
+			.region(reqDto.getRegion())
+			.build();
+		planner.setUsers(users);
+
+		Category category = categoryMapper.findCategoryByContentOrElseCreate(CategoryEnum.PLANNER.name());
+		List<Tag> tagList = reqDto.getPlannerTagList()
+			.stream().filter(Objects::nonNull)
+			.map(content -> tagMapper.contentToEntity(content, category))
+			.toList();
+		List<PlannerTag> plannerTagList = tagList
+			.stream().filter(Objects::nonNull)
+			.map(tag -> plannerTagMapper.plannerToEntity(planner, tag))
+			.toList();
+
+		planner.createPlannerTagList(plannerTagList);
+		return planner;
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/mapper/PlannerTagMapper.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/mapper/PlannerTagMapper.java
@@ -1,0 +1,29 @@
+package swmaestro.spaceodyssey.weddingmate.domain.users.mapper;
+
+import org.springframework.stereotype.Component;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import swmaestro.spaceodyssey.weddingmate.domain.tag.entity.Tag;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Customer;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Planner;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.PlannerTag;
+
+@Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlannerTagMapper {
+
+	public PlannerTag plannerToEntity(Planner planner, Tag tag){
+		return PlannerTag.plannerBuilder()
+			.planner(planner)
+			.tag(tag)
+			.build();
+	}
+
+	public PlannerTag customerToEntity(Customer customer, Tag tag){
+		return PlannerTag.customerBuilder()
+			.customer(customer)
+			.tag(tag)
+			.build();
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/repository/CustomerRepository.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/repository/CustomerRepository.java
@@ -1,0 +1,8 @@
+package swmaestro.spaceodyssey.weddingmate.domain.users.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Customer;
+
+public interface CustomerRepository extends JpaRepository<Customer, Long> {
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/repository/PlannerRepository.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/repository/PlannerRepository.java
@@ -1,0 +1,8 @@
+package swmaestro.spaceodyssey.weddingmate.domain.users.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Planner;
+
+public interface PlannerRepository extends JpaRepository<Planner, Long> {
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/repository/PlannerTagRepository.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/repository/PlannerTagRepository.java
@@ -1,0 +1,8 @@
+package swmaestro.spaceodyssey.weddingmate.domain.users.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.PlannerTag;
+
+public interface PlannerTagRepository extends JpaRepository<PlannerTag, Long> {
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/repository/UsersRepository.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/repository/UsersRepository.java
@@ -9,5 +9,7 @@ import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
 public interface UsersRepository extends JpaRepository<Users, Long> {
 	Optional<Users> findByEmail(String email);
 
+	Optional<Users> findByNickname(String nickname);
+
 	Optional<Users> findByAuthProviderId(String authProviderId);
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/service/UsersService.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/service/UsersService.java
@@ -1,0 +1,71 @@
+package swmaestro.spaceodyssey.weddingmate.domain.users.service;
+
+import java.util.Objects;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import swmaestro.spaceodyssey.weddingmate.domain.users.dto.CustomerSignupReqDto;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Customer;
+import swmaestro.spaceodyssey.weddingmate.domain.users.mapper.CustomerMapper;
+import swmaestro.spaceodyssey.weddingmate.domain.users.mapper.PlannerMapper;
+import swmaestro.spaceodyssey.weddingmate.domain.users.dto.PlannerSignupReqDto;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Planner;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
+import swmaestro.spaceodyssey.weddingmate.domain.users.repository.CustomerRepository;
+import swmaestro.spaceodyssey.weddingmate.domain.users.repository.PlannerRepository;
+import swmaestro.spaceodyssey.weddingmate.domain.users.repository.UsersRepository;
+import swmaestro.spaceodyssey.weddingmate.global.exception.users.UserNotFoundException;
+
+@Service
+@RequiredArgsConstructor
+public class UsersService {
+
+	private final UsersRepository usersRepository;
+	private final PlannerRepository plannerRepository;
+	private final CustomerRepository customerRepository;
+
+	private final PlannerMapper plannerMapper;
+	private final CustomerMapper customerMapper;
+
+	@Transactional
+	public void signupPlanner(Users users, PlannerSignupReqDto reqDto) {
+		Users pUsers = findUserByEmail(users, reqDto.getNickname());
+		pUsers.updateNickname(reqDto.getNickname());
+
+		Planner planner = plannerMapper.toEntity(pUsers, reqDto);
+		plannerRepository.save(planner);
+	}
+
+	@Transactional
+	public void signupCustomer(Users users, CustomerSignupReqDto reqDto) {
+		System.out.println("서비스 진입");
+		Users pUsers = findUserByEmail(users, reqDto.getNickname());
+		pUsers.updateNickname(reqDto.getNickname());
+
+		System.out.println("유저 닉네임 업데이트 완");
+		Customer customer = customerMapper.toEntity(pUsers, reqDto);
+		customerRepository.save(customer);
+	}
+
+	@Transactional
+	public Users findUserByEmail(Users users, String nickname) {
+		Users pUsers = usersRepository.findByEmail(users.getEmail())
+			.orElseThrow(UserNotFoundException::new);
+		if (isEntityManaged(pUsers)){
+			return pUsers;
+		}
+		else
+			return null;
+	}
+
+	@Autowired
+	private EntityManager entityManager;
+
+	public boolean isEntityManaged(Users user) {
+		return entityManager.contains(user);
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/service/UsersService.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/service/UsersService.java
@@ -1,11 +1,7 @@
 package swmaestro.spaceodyssey.weddingmate.domain.users.service;
 
-import java.util.Objects;
-
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import swmaestro.spaceodyssey.weddingmate.domain.users.dto.CustomerSignupReqDto;
@@ -33,39 +29,27 @@ public class UsersService {
 
 	@Transactional
 	public void signupPlanner(Users users, PlannerSignupReqDto reqDto) {
-		Users pUsers = findUserByEmail(users, reqDto.getNickname());
+		Users pUsers = findUserByEmail(users.getEmail());
 		pUsers.updateNickname(reqDto.getNickname());
 
-		Planner planner = plannerMapper.toEntity(pUsers, reqDto);
+		Planner planner = plannerMapper.toEntity(reqDto);
+		planner.setUsers(pUsers);
 		plannerRepository.save(planner);
 	}
 
 	@Transactional
 	public void signupCustomer(Users users, CustomerSignupReqDto reqDto) {
-		System.out.println("서비스 진입");
-		Users pUsers = findUserByEmail(users, reqDto.getNickname());
+		Users pUsers = findUserByEmail(users.getEmail());
 		pUsers.updateNickname(reqDto.getNickname());
 
-		System.out.println("유저 닉네임 업데이트 완");
-		Customer customer = customerMapper.toEntity(pUsers, reqDto);
+		Customer customer = customerMapper.toEntity(reqDto);
+		customer.setUsers(pUsers);
 		customerRepository.save(customer);
 	}
 
 	@Transactional
-	public Users findUserByEmail(Users users, String nickname) {
-		Users pUsers = usersRepository.findByEmail(users.getEmail())
+	public Users findUserByEmail(String email) {
+		return usersRepository.findByEmail(email)
 			.orElseThrow(UserNotFoundException::new);
-		if (isEntityManaged(pUsers)){
-			return pUsers;
-		}
-		else
-			return null;
-	}
-
-	@Autowired
-	private EntityManager entityManager;
-
-	public boolean isEntityManaged(Users user) {
-		return entityManager.contains(user);
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/global/constant/ResponseConstant.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/global/constant/ResponseConstant.java
@@ -10,6 +10,11 @@ public class ResponseConstant {
 	public static final String LOGIN_SUCCESS = "성공적으로 로그인되었습니다.";
 
 	/* USERS */
+	// planner
+	public static final String PLANNER_SIGNUP_SUCCESS = " 플래너님의 회원가입이 완료되었습니다.";
+
+	// customer
+	public static final String CUSTOMER_SIGNUP_SUCCESS = " 고객님의 회원가입이 완료되었습니다.";
 
 	// exception
 	public static final String USER_NOTFOUND = "해당 유저를 찾을 수 없습니다.";

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,20 +15,13 @@ spring:
         format_sql: true       # sql format 설정
         use_sql_comments: true # 주석 표시
         highlight_sql: true    # ANSI SQL에 맞게 색 출력
+        type: trace
 
   # file 관련 설정
   servlet:
     multipart:
       max-request-size: 30MB
       max-file-size: 30MB
-
-  logging:
-    level:
-      org:
-        hibernate:
-          type:
-            descriptor:
-              sql: trace # parameter 값을 표시
 
   jwt:
     secret: ${JWT_SECRET}
@@ -37,3 +30,13 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+
+logging:
+  level:
+     org:
+       springframework:
+         transaction: DEBUG
+       hibernate:
+         type:
+           descriptor:
+             sql: trace # parameter 값을 표시


### PR DESCRIPTION
### 작업 개요
OAuth2로 User 객체 생성 후 플래너, 예비부부별로 추가 정보를 받아 회원가입하는 기능 구현

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- Planner, Customer는 User를 상속받지 않고 @OneToOne 조인 방식으로 구현
- Planner의 경우 plannerTag 사용
- Customer의 경우 portfolioTag, plannerTag 사용
- portfolioTag에 customer 관련 의존성 추가

### 생각해볼 문제
- 원래는 상속을 이용해서 single table이나 joined 방식으로 구현하려 했으나, 상속을 이용하려면 User entity를 추상 클래스로 정의해야 함. 하지만 현재 구현 방식은 OAuth2 구현 후 User 객체를 생성하여 db에 저장해야 하기 때문에 User를 일반 클래스로 정의하고 Planner와 Customer와 1:1 매핑하는 방식을 사용
- 현재 무슨 이유에서인지 영속성 컨텍스트가 작동하지 않는 것 같음 -> 해결(https://github.com/SWM-Space-Odyssey/WeddingMate_BackEnd/discussions/33)