### PR TITLE
[SO-143] feat :  도메인 적용 및 redirect 주소 변경

### DIFF
--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
@@ -48,7 +48,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 	private String makeRedirectUrl(String email) {
 		String accessToken = tokenProvider.createAccessToken(email);
 
-		return UriComponentsBuilder.fromHttpUrl("http://weddingmate-fe-bucket.s3-website.ap-northeast-2.amazonaws.com")
+		return UriComponentsBuilder.fromHttpUrl("http://weddingmate.co.kr")
 			.queryParam("accessToken", accessToken)
 			.build()
 			.encode()

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/global/config/SecurityConfig.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/global/config/SecurityConfig.java
@@ -87,6 +87,7 @@ public class SecurityConfig {
 		configuration.addAllowedOriginPattern("*"); // 모든 IP 주소 허용 (프론트엔드 IP, react만 허용) 핸드폰은 js 요청을 하지 않고 java나 swift 쓰기 때문에 cors에 안 걸림
 		configuration.addAllowedOrigin("http://weddingmate-fe-bucket.s3-website.ap-northeast-2.amazonaws.com");
 		configuration.addAllowedOrigin("http://localhost:5173");
+		configuration.addAllowedOrigin("http://weddingmate.co.kr");
 		configuration.setAllowCredentials(true); // 클라이언트에서 쿠키 요청 허용
 		configuration.setMaxAge(MAX_AGE_SECS);
 


### PR DESCRIPTION
### 작업 개요
- 새로 구입한 도메인으로 redirect 주소 변경

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
1. 프론트 도메인 주소와 백엔드 도메인 주소가 달라 중간 과정에서 쿠키가 막힘
2. 공통 도메인을 사용하는 것으로 변경(FE: weddingmate.co.kr, BE: api.weddingmate.co.kr)

### 생각해볼 문제
1. 추후 FE와 BE 도메인 둘 다 https 연결을 위한 설정이 필요합니다. 현재 ssl 인증을 위한 acm 인증서 발급 요청을 해놓은 상태입니다.