### PR TITLE
[SO-147] feat : 사용하지 않는 docker image 삭제, AWS ECR로 백업

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,4 +75,4 @@ jobs:
           username: ubuntu
           key: ${{ secrets.KEY }}
           script: |
-            sh /home/ubuntu/srv/ubuntu/config/scripts/delete.sh
+            sh /home/ubuntu/srv/weddingmate/config/scripts/delete.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,17 @@ jobs:
       - name: checkout #branch로 checkout
         uses: actions/checkout@main
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+        
       - name: create env file
         run: |
           touch .env
@@ -36,6 +47,17 @@ jobs:
           remote_host: ${{ secrets.HOST }}
           remote_user: ubuntu
           remote_key: ${{ secrets.KEY }}
+          
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: weddingmate
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
       - name: executing remote ssh commands using password
         uses: appleboy/ssh-action@master
@@ -44,13 +66,13 @@ jobs:
           username: ubuntu
           key: ${{ secrets.KEY }}
           script: |
-            sh /home/ubuntu/srv/weddingmate/config/scripts/deploy.sh
+            sh /home/ubuntu/srv/weddingmate/config/scripts/deploy.sh ${{github.sha}}
 
-#      - name: delete unused images and containers
-#        uses: appleboy/ssh-action@master
-#        with:
-#          host: ${{ secrets.HOST }}
-#          username: ubuntu
-#          key: ${{ secrets.KEY }}
-#          script: |
-#            sh /home/ubuntu/srv/ubuntu/config/scripts/delete.sh
+      - name: delete unused images and containers
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ubuntu
+          key: ${{ secrets.KEY }}
+          script: |
+            sh /home/ubuntu/srv/ubuntu/config/scripts/delete.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to EC2
 on: #develop branch에 push 될 경우에만 수행
   push:
     branches:
-      - develop
+      - feature/SO-147-delete-unused-docker-image
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to EC2
 on: #develop branch에 push 될 경우에만 수행
   push:
     branches:
-      - feature/SO-147-delete-unused-docker-image
+      - develop
 
 jobs:
   build:

--- a/config/scripts/delete.sh
+++ b/config/scripts/delete.sh
@@ -1,0 +1,2 @@
+sudo yes y | sudo docker image prune
+sudo yes y | sudo docker container prune

--- a/config/scripts/deploy.sh
+++ b/config/scripts/deploy.sh
@@ -1,3 +1,6 @@
+#tag는 첫번째 인수
+TAG=$1
+
 #docker가 없다면 docker 설치
 if ! type docker > /dev/null
 then
@@ -24,4 +27,6 @@ fi
 echo "start docker-compose up: ubuntu"
 sudo docker-compose -f /home/ubuntu/srv/weddingmate/docker-compose.prod.yml down
 
-sudo docker-compose -f /home/ubuntu/srv/weddingmate/docker-compose.prod.yml up --build -d
+aws ecr get-login-password --region ap-northeast-2 | sudo docker login --username AWS --password-stdin 231494810622.dkr.ecr.ap-northeast-2.amazonaws.com
+sudo docker pull 231494810622.dkr.ecr.ap-northeast-2.amazonaws.com/weddingmate:$TAG
+sudo TAG=$TAG docker-compose -f /home/ubuntu/srv/weddingmate/docker-compose.prod.yml up --build -d


### PR DESCRIPTION
### 작업 개요
- ec2 내의 용량 부족 문제로 deploy 시 오류 발생
- 사용하지 않는 Docker image & container 삭제 script 추가
- 추후 CD로직 추가 및 이미지 백업을 위해 AWS ECR에 이미지 백업

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
1. delete.sh script 추가
2. deploy.yml에 ECR에 로그인 및 image push 로직 추가
3. { github.sha } 로 이미지 tagging

### 생각해볼 문제
1. github action deploy에 실패 시 AWS ECR에 백업되어있는 이미지로 이를 재가동하는 로직을 추가하면 더 좋은 CD flow가 될 것 같습니다.