### PR TITLE
[SO-150] feat: RefreshToken 도메인 수정

### DIFF
--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
@@ -98,7 +98,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
 		return ResponseCookie.from("refreshToken", refreshToken)
 			.path("/") // 해당 경로 하위의 페이지에서만 쿠키 접근 허용. 모든 경로에서 접근 허용한다.
-			.domain("weddingmate.co.kr")
+			.domain(".weddingmate.co.kr")
 			.maxAge(TimeUnit.MILLISECONDS.toSeconds(refreshTokenValidationTime)) // 쿠키 만료 시기(초). 없으면 브라우저 닫힐 때 제거
 			.secure(true) // HTTPS로 통신할 때만 쿠키가 전송된다.
 			.sameSite("None") // 크로스 사이트에도 쿠키 전송 가능


### PR DESCRIPTION
### 작업 개요
redis에 넣어지는 refreshToken과 실제 전달되는 refreshToken값이 다른 것을 확인

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
하위 도메인에서도 접근 가능하도록 .weddingmate.co.kr로 수정

### 생각해볼 문제