### PR TITLE
[SO-150] fix: cookie param snake case로 변경

### DIFF
--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
@@ -98,7 +98,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
 		return ResponseCookie.from("refreshToken", refreshToken)
 			.path("/") // 해당 경로 하위의 페이지에서만 쿠키 접근 허용. 모든 경로에서 접근 허용한다.
-			.domain("weddingmate.co.kr")
+			.domain(".weddingmate.co.kr")
 			.maxAge(TimeUnit.MILLISECONDS.toSeconds(refreshTokenValidationTime)) // 쿠키 만료 시기(초). 없으면 브라우저 닫힐 때 제거
 			.secure(true) // HTTPS로 통신할 때만 쿠키가 전송된다.
 			.sameSite("None") // 크로스 사이트에도 쿠키 전송 가능

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/oauth2/service/CookieAuthorizationRequestRepository.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/oauth2/service/CookieAuthorizationRequestRepository.java
@@ -17,7 +17,7 @@ public class CookieAuthorizationRequestRepository
 	implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
 
 	public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_KEY = "oauth2AuthRequest";
-	public static final String REDIRECT_URL_PARAM_COOKIE_KEY = "redirectUrl";
+	public static final String REDIRECT_URL_PARAM_COOKIE_KEY = "redirect_uri";
 	private static final int COOKIE_EXPIRE_SECONDS = 180;
 
 	// 쿠키에 저장된 인증 요청 정보 가져오기


### PR DESCRIPTION
### 작업 개요
oauth2 로그인 시 param의 값을 잘 인식할 수 있도록 camel case에서 snake case로 변경

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
기존 redirectUrl -> redirect_uri로 변경
oauth2 로그인 시 카멜 케이스에 대한 인식을 못하는 이슈가 있어 스네이크 케이스로 변수명 변경

### 생각해볼 문제