### PR TITLE
[SO-148] feat: API 공통 응답 포맷 생성

### DIFF
--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/category/controller/CategoryController.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/category/controller/CategoryController.java
@@ -1,15 +1,15 @@
 package swmaestro.spaceodyssey.weddingmate.domain.category.controller;
 
-import java.util.List;
-
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
-import swmaestro.spaceodyssey.weddingmate.domain.category.dto.CategoryResDto;
 import swmaestro.spaceodyssey.weddingmate.domain.category.service.CategoryService;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponse;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponseStatus;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,7 +19,11 @@ public class CategoryController {
 	private final CategoryService categoryService;
 
 	@GetMapping("/all")
-	public ResponseEntity<List<CategoryResDto>> getAllCategory() {
-		return  ResponseEntity.ok().body(categoryService.findAllCategory());
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<Object> getAllCategory() {
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(categoryService.findAllCategory())
+			.build();
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/file/controller/FileController.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/file/controller/FileController.java
@@ -1,10 +1,8 @@
 package swmaestro.spaceodyssey.weddingmate.domain.file.controller;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,11 +15,12 @@ import org.springframework.web.multipart.MultipartFile;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import swmaestro.spaceodyssey.weddingmate.domain.file.dto.ItemFileReqDto;
-import swmaestro.spaceodyssey.weddingmate.domain.file.dto.ImageListResDto;
 import swmaestro.spaceodyssey.weddingmate.domain.file.service.FileService;
 import swmaestro.spaceodyssey.weddingmate.domain.file.service.FileUploadService;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.AuthUsers;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponse;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponseStatus;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,27 +31,41 @@ public class FileController {
 	private final FileService fileService;
 
 	@PostMapping("/items")
-	@ResponseStatus(value = HttpStatus.CREATED)
-	public ResponseEntity<String> postItem(@RequestPart ItemFileReqDto itemFileReqDto,
+	@ResponseStatus(HttpStatus.CREATED)
+	public ApiResponse<Object> postItem(@RequestPart ItemFileReqDto itemFileReqDto,
 											@NotNull @RequestPart("file") MultipartFile multipartFile) {
-		return ResponseEntity.ok().body(fileUploadService.uploadItemFile(itemFileReqDto, multipartFile));
+
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(fileUploadService.uploadItemFile(itemFileReqDto, multipartFile))
+			.build();
 	}
 
 	@PostMapping("/profile")
-	@ResponseStatus(value = HttpStatus.OK)
-	public ResponseEntity<String> updateProfile(@AuthUsers Users users,
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<Object> updateProfile(@AuthUsers Users users,
 												@NotNull @RequestPart("file") MultipartFile multipartFile) {
-		return ResponseEntity.ok().body(fileUploadService.updateProfileFile(users, multipartFile));
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(fileUploadService.updateProfileFile(users, multipartFile))
+			.build();
 	}
 
 	@DeleteMapping("/profile")
-	@ResponseStatus(value = HttpStatus.OK)
-	public ResponseEntity<String> deleteProfile(@AuthUsers Users users) {
-		return ResponseEntity.ok().body(fileUploadService.deleteProfileFile(users));
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<Object> deleteProfile(@AuthUsers Users users) {
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(fileUploadService.deleteProfileFile(users))
+			.build();
   }
 
 	@GetMapping()
-	public ResponseEntity<Page<ImageListResDto>> getImagePage(@PageableDefault(size = 18) Pageable pageable) {
-		return ResponseEntity.ok().body(fileService.getImage(pageable));
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<Object> getImagePage(@PageableDefault(size = 18) Pageable pageable) {
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(fileService.getImage(pageable))
+			.build();
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/item/controller/ItemController.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/item/controller/ItemController.java
@@ -1,7 +1,8 @@
 package swmaestro.spaceodyssey.weddingmate.domain.item.controller;
 
+import static swmaestro.spaceodyssey.weddingmate.global.constant.ResponseConstant.*;
+
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -9,15 +10,17 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
-import swmaestro.spaceodyssey.weddingmate.domain.item.dto.ItemResDto;
 import swmaestro.spaceodyssey.weddingmate.domain.item.dto.ItemSaveReqDto;
 import swmaestro.spaceodyssey.weddingmate.domain.item.dto.ItemUpdateReqDto;
 import swmaestro.spaceodyssey.weddingmate.domain.item.service.ItemService;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.AuthUsers;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponse;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponseStatus;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,25 +29,41 @@ public class ItemController {
 
 	private final ItemService itemService;
 	@PostMapping("/save")
-	public ResponseEntity<HttpStatus> createItem(@RequestBody ItemSaveReqDto itemSaveReqDto) {
+	@ResponseStatus(HttpStatus.CREATED)
+	public ApiResponse<Object> createItem(@RequestBody ItemSaveReqDto itemSaveReqDto) {
 		itemService.createItem(itemSaveReqDto);
-		return ResponseEntity.ok().body(HttpStatus.CREATED);
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(ITEM_CREATE_SUCCESS)
+			.build();
 	}
 
 	@GetMapping("/{id}")
-	public ResponseEntity<ItemResDto> getItemById(@PathVariable("id") Long id) {
-		return ResponseEntity.ok().body(itemService.findById(id));
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<Object> getItemById(@PathVariable("id") Long id) {
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(itemService.findById(id))
+			.build();
 	}
 
 	@PutMapping("/{id}")
-	public ResponseEntity<HttpStatus> updateItem(@AuthUsers Users users, @PathVariable("id") Long id, @RequestBody ItemUpdateReqDto itemUpdateReqDto) {
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<Object> updateItem(@AuthUsers Users users, @PathVariable("id") Long id, @RequestBody ItemUpdateReqDto itemUpdateReqDto) {
 		itemService.update(users, id, itemUpdateReqDto);
-		return ResponseEntity.ok().body(HttpStatus.OK);
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(ITEM_UPDATE_SUCCESS)
+			.build();
 	}
 
 	@DeleteMapping("/{id}")
-	public ResponseEntity<HttpStatus> deleteItem(@AuthUsers Users users, @PathVariable("id") Long id) {
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<Object> deleteItem(@AuthUsers Users users, @PathVariable("id") Long id) {
 		itemService.delete(users, id);
-		return ResponseEntity.ok().body(HttpStatus.OK);
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(ITEM_DELETE_SUCCESS)
+			.build();
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/controller/PortfolioController.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/controller/PortfolioController.java
@@ -1,10 +1,10 @@
 package swmaestro.spaceodyssey.weddingmate.domain.portfolio.controller;
 
+import static swmaestro.spaceodyssey.weddingmate.global.constant.ResponseConstant.*;
+
 import java.io.IOException;
-import java.util.List;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,18 +12,19 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
-import swmaestro.spaceodyssey.weddingmate.domain.portfolio.dto.PortfolioDetailResDto;
-import swmaestro.spaceodyssey.weddingmate.domain.portfolio.dto.PortfolioListResDto;
 import swmaestro.spaceodyssey.weddingmate.domain.portfolio.dto.PortfolioSaveReqDto;
 import swmaestro.spaceodyssey.weddingmate.domain.portfolio.dto.PortfolioUpdateReqDto;
 import swmaestro.spaceodyssey.weddingmate.domain.portfolio.service.PortfolioService;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.AuthUsers;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponse;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponseStatus;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,34 +34,55 @@ public class PortfolioController {
 	private final PortfolioService portfolioService;
 
 	@PostMapping("/save")
-	public ResponseEntity<HttpStatus> createPortfolio(@AuthUsers Users users, @NotNull @RequestPart("file") MultipartFile multipartFile,
-															@RequestPart PortfolioSaveReqDto portfolioSaveReqDto) throws
-		IOException {
+	@ResponseStatus(HttpStatus.CREATED)
+	public ApiResponse<Object> createPortfolio(@AuthUsers Users users,
+											@NotNull @RequestPart("file") MultipartFile multipartFile,
+											@RequestPart PortfolioSaveReqDto portfolioSaveReqDto) throws IOException {
 		portfolioService.createPortfolio(users, multipartFile, portfolioSaveReqDto);
-		return ResponseEntity.ok().body(HttpStatus.CREATED);
+
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(PORTFOLIO_CREATE_SUCCESS)
+			.build();
 	}
 
 	@GetMapping("/")
-	public ResponseEntity<List<PortfolioListResDto>> getPortfolioByUser(@AuthUsers Users users) {
-		return  ResponseEntity.ok().body(portfolioService.findByUser(users.getUserId()));
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<Object> getPortfolioByUser(@AuthUsers Users users) {
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(portfolioService.findByUser(users.getUserId()))
+			.build();
 	}
 
 	@GetMapping("/{id}")
-	public ResponseEntity<PortfolioDetailResDto> getPortfolioById(@PathVariable("id") Long id) {
-		return ResponseEntity.ok().body(portfolioService.findById(id));
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<Object> getPortfolioById(@PathVariable("id") Long id) {
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(portfolioService.findById(id))
+			.build();
 	}
 
 	@PutMapping("/{id}")
-	public ResponseEntity<HttpStatus> updatePortfolio(@AuthUsers Users users, @PathVariable("id") Long id, @RequestPart(value = "file") MultipartFile multipartFile,
-																	@RequestPart PortfolioUpdateReqDto portfolioUpdateReqDto) throws
-		IOException {
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<Object> updatePortfolio(@AuthUsers Users users, @PathVariable("id") Long id,
+												@RequestPart(value = "file") MultipartFile multipartFile,
+												@RequestPart PortfolioUpdateReqDto portfolioUpdateReqDto) throws IOException {
 		portfolioService.updatePortfolio(users, id, portfolioUpdateReqDto, multipartFile);
-		return ResponseEntity.ok().body(HttpStatus.OK);
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(PORTFOLIO_UPDATE_SUCCESS)
+			.build();
 	}
 
 	@DeleteMapping("/{id}")
-	public ResponseEntity<HttpStatus> deletePortfolio(@AuthUsers Users users, @PathVariable("id") Long id) {
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<Object> deletePortfolio(@AuthUsers Users users, @PathVariable("id") Long id) {
 		portfolioService.deletePortfolio(users, id);
-		return ResponseEntity.ok().body(HttpStatus.OK);
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(PORTFOLIO_DELETE_SUCCESS)
+			.build();
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/controller/UserProfileController.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/controller/UserProfileController.java
@@ -1,11 +1,11 @@
 package swmaestro.spaceodyssey.weddingmate.domain.profile.controller;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
@@ -15,6 +15,8 @@ import swmaestro.spaceodyssey.weddingmate.domain.profile.dto.PlannerProfileUpdat
 import swmaestro.spaceodyssey.weddingmate.domain.profile.service.ProfileService;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.AuthUsers;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponse;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponseStatus;
 
 @RestController
 @RequestMapping("/api/v1/profile")
@@ -24,14 +26,22 @@ public class UserProfileController { // profileController가 spring 기본 confi
 	private final ProfileService profileService;
 
 	@GetMapping("/planner")
-	public ResponseEntity<PlannerProfileResDto> getPlannerProfile(@AuthUsers Users users) {
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<Object> getPlannerProfile(@AuthUsers Users users) {
 		PlannerProfileResDto resDto = profileService.getPlannerProfile(users);
-		return new ResponseEntity<>(resDto, HttpStatus.OK);
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(resDto)
+			.build();
 	}
 
 	@PutMapping("/planner")
-	public ResponseEntity<PlannerProfileUpdateResDto> updatePlannerProfile(@RequestBody PlannerProfileUpdateReqDto reqDto) {
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<Object> updatePlannerProfile(@RequestBody PlannerProfileUpdateReqDto reqDto) {
 		PlannerProfileUpdateResDto resDto = profileService.updatePlannerProfile(reqDto);
-		return new ResponseEntity<>(resDto, HttpStatus.OK);
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(resDto)
+			.build();
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/tag/controller/TagController.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/tag/controller/TagController.java
@@ -1,16 +1,16 @@
 package swmaestro.spaceodyssey.weddingmate.domain.tag.controller;
 
-import java.util.List;
-
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
-import swmaestro.spaceodyssey.weddingmate.domain.tag.dto.TagResDto;
 import swmaestro.spaceodyssey.weddingmate.domain.tag.service.TagService;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponse;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponseStatus;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,7 +19,11 @@ public class TagController {
 	private final TagService tagService;
 
 	@GetMapping("/all")
-	public ResponseEntity<List<TagResDto>> getAllTag(@RequestParam String category) {
-		return  ResponseEntity.ok().body(tagService.findAllTag(category));
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<Object> getAllTag(@RequestParam String category) {
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(tagService.findAllTag(category))
+			.build();
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/controller/AuthController.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/controller/AuthController.java
@@ -2,6 +2,7 @@ package swmaestro.spaceodyssey.weddingmate.domain.users.controller;
 
 import static org.springframework.http.HttpHeaders.*;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import swmaestro.spaceodyssey.weddingmate.domain.users.dto.AccessTokenDto;
 import swmaestro.spaceodyssey.weddingmate.domain.users.service.AuthService;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponse;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponseStatus;
 
 @Slf4j
 @RestController
@@ -21,24 +24,31 @@ public class AuthController {
 	private final AuthService authService;
 
 	@PostMapping("/refresh")
-	public ResponseEntity<AccessTokenDto> refresh(
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<Object> refresh(
 		@CookieValue(value = "refreshToken", required = false) Cookie rtCookie) {
 
 		String refreshToken = rtCookie.getValue();
 		AccessTokenDto resDto = authService.refresh(refreshToken);
 
-		return ResponseEntity.ok()
-			.body(resDto);
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(resDto)
+			.build();
 	}
 
 	@PostMapping("/blacklist")
-	public ResponseEntity<AccessTokenDto> signOut(@RequestBody AccessTokenDto requestDto) {
+	@ResponseStatus(HttpStatus.OK)
+	public ResponseEntity<ApiResponse<Object>> signOut(@RequestBody AccessTokenDto requestDto) {
 		AccessTokenDto resDto = authService.signOut(requestDto);
 		ResponseCookie responseCookie = removeRefreshTokenCookie();
 
 		return ResponseEntity.ok()
 			.header(SET_COOKIE, responseCookie.toString())
-			.body(resDto);
+			.body(ApiResponse.builder()
+				.status(ApiResponseStatus.SUCCESS)
+				.data(resDto)
+				.build());
 	}
 
 	public ResponseCookie removeRefreshTokenCookie() {

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/global/constant/ResponseConstant.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/global/constant/ResponseConstant.java
@@ -32,8 +32,16 @@ public class ResponseConstant {
 	public static final String OAUTH_UNAUTHORIZED_URL = "해당 url은 인증되지 않았습니다.";
 
 	/* PORTFOLIO */
-	public static final String PORTFOLIO_NOTFOUND = "포트폴리오를 찾을 수 없습니다";
+	public static final String PORTFOLIO_NOTFOUND = "해당 포트폴리오를 찾을 수 없습니다";
+	public static final String PORTFOLIO_CREATE_SUCCESS = "해당 포트폴리오를 생성했습니다.";
+	public static final String PORTFOLIO_UPDATE_SUCCESS = "해당 포트폴리오를 수정했습니다.";
+	public static final String PORTFOLIO_DELETE_SUCCESS = "해당 포트폴리오를 삭제했습니다.";
+
+	/* ITEM */
 	public static final String ITEM_NOTFOUND = "해당 아이템을 찾을 수 없습니다";
+	public static final String ITEM_CREATE_SUCCESS = "해당 아이템을 생성했습니다.";
+	public static final String ITEM_UPDATE_SUCCESS = "해당 아이템을 수정했습니다.";
+	public static final String ITEM_DELETE_SUCCESS = "해당 아이템을 삭제했습니다.";
 
 	/* CATEGORY */
 	public static final String CATEGORY_NOTFOUND = "카테고리를 찾을 수 없습니다";

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/global/dto/ApiResponse.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/global/dto/ApiResponse.java
@@ -1,0 +1,30 @@
+package swmaestro.spaceodyssey.weddingmate.global.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonInclude(JsonInclude.Include.NON_NULL) // null값이면 응답에서 제외
+public class ApiResponse<T> {
+	private ApiResponseStatus status; // success, fail, error
+	private String message;
+	private T data; // errorResponse
+
+	@Builder
+	public ApiResponse(ApiResponseStatus status, String message, T data) {
+		this.status = status;
+		this.message = message;
+		this.data = data;
+	}
+
+	@Builder
+	public ApiResponse(ApiResponseStatus status, T data) {
+		this.status = status;
+		this.data = data;
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/global/dto/ApiResponseStatus.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/global/dto/ApiResponseStatus.java
@@ -1,0 +1,19 @@
+package swmaestro.spaceodyssey.weddingmate.global.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public enum ApiResponseStatus {
+	SUCCESS("success"),
+	FAIL("fail"),
+	ERROR("error");
+
+	private String value;
+
+	ApiResponseStatus(String value){
+		this.value = value;
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/global/exception/handler/ErrorResponse.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/global/exception/handler/ErrorResponse.java
@@ -1,15 +1,15 @@
 package swmaestro.spaceodyssey.weddingmate.global.exception.handler;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 
 import lombok.Builder;
 import lombok.Getter;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponse;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponseStatus;
 
 @Getter
 public class ErrorResponse {
 	private HttpStatus status;
-	private static final Boolean success = false;
 	private ErrorCode code;
 	private String message;
 
@@ -20,13 +20,16 @@ public class ErrorResponse {
 		this.message = message;
 	}
 
-	public static ResponseEntity<ErrorResponse> toErrorResponseEntity(ErrorCode code, String message) {
+	public static ApiResponse<Object> toErrorResponseEntity(ErrorCode code, String message) {
 		ErrorResponse response = ErrorResponse.builder()
 			.status(code.getStatus())
 			.code(code)
 			.message(message)
 			.build();
 
-		return ResponseEntity.status(response.getStatus()).body(response);
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.FAIL)
+			.data(response)
+			.build();
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/global/exception/handler/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponse;
 import swmaestro.spaceodyssey.weddingmate.global.exception.category.CategoryNotFoundException;
 import swmaestro.spaceodyssey.weddingmate.global.exception.file.FileKakaoProfileDownloadFailureException;
 import swmaestro.spaceodyssey.weddingmate.global.exception.file.FileMalformedUrlException;
@@ -44,126 +45,126 @@ public class GlobalExceptionHandler {
 
 	/*================== Oauth2 Exception ==================*/
 	@ExceptionHandler(OAuth2AuthProviderIdNotFoundException.class)
-	protected final ResponseEntity<ErrorResponse> handleOAuth2ProviderIdNotFoundException(
+	protected final ApiResponse<Object> handleOAuth2ProviderIdNotFoundException(
 		OAuth2AuthProviderIdNotFoundException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.OAUTH_PROVIDERID_NOTFOUND, e.getMessage());
 	}
 
 	@ExceptionHandler(OAuth2DuplicateEmailException.class)
-	protected final ResponseEntity<ErrorResponse> handleOAuth2DuplicateEmailException(OAuth2DuplicateEmailException e) {
+	protected final ApiResponse<Object> handleOAuth2DuplicateEmailException(OAuth2DuplicateEmailException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.OAUTH_DUPLICATE_EMAIL, e.getMessage());
 	}
 
 	@ExceptionHandler(OAuthUnauthUrlException.class)
-	protected final ResponseEntity<ErrorResponse> handleOAuthUnauthUrlException(OAuthUnauthUrlException e) {
+	protected final ApiResponse<Object> handleOAuthUnauthUrlException(OAuthUnauthUrlException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.OAUTH_UNAUTHORIZED_URL, e.getMessage());
 	}
 
 	/*================== User Exception ==================*/
 	@ExceptionHandler(UserNotFoundException.class)
-	protected final ResponseEntity<ErrorResponse> handleUserNotFoundException(UserNotFoundException e) {
+	protected final ApiResponse<Object> handleUserNotFoundException(UserNotFoundException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.USER_NOTFOUND, e.getMessage());
 	}
 
 	@ExceptionHandler(UserNameNotFoundException.class)
-	protected final ResponseEntity<ErrorResponse> handleUserNameNotFoundException(UserNameNotFoundException e) {
+	protected final ApiResponse<Object> handleUserNameNotFoundException(UserNameNotFoundException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.USER_NAME_NOTFOUND, e.getMessage());
 	}
 
 	@ExceptionHandler(UserUnAuthorizedException.class)
-	protected final ResponseEntity<ErrorResponse> handleUserUnAuthorizedException(UserUnAuthorizedException e) {
+	protected final ApiResponse<Object> handleUserUnAuthorizedException(UserUnAuthorizedException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.USER_UNAUTHORIZED, e.getMessage());
 	}
 
 	// Planner Exception
 	@ExceptionHandler(PlannerNotFoundException.class)
-	protected final ResponseEntity<ErrorResponse> handlerPlannerNotFoundException(PlannerNotFoundException e) {
+	protected final ApiResponse<Object> handlerPlannerNotFoundException(PlannerNotFoundException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.PLANNER_NOTFOUND, e.getMessage());
 	}
 
 	@ExceptionHandler(PlannerDuplicateRegistrationException.class)
-	protected final ResponseEntity<ErrorResponse> handlePlannerDuplicateRegistrationException(
+	protected final ApiResponse<Object> handlePlannerDuplicateRegistrationException(
 		PlannerDuplicateRegistrationException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.PLANNER_DUPLICATE_REGISTRATION, e.getMessage());
 	}
 
 	// Customer Exception
 	@ExceptionHandler(CustomerDuplicateRegistrationException.class)
-	protected final ResponseEntity<ErrorResponse> handleCustomerDuplicateResgistrationException(
+	protected final ApiResponse<Object> handleCustomerDuplicateResgistrationException(
 		CustomerDuplicateRegistrationException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.CUSTOMER_DUPLICATE_REGISTRATION, e.getMessage());
 	}
 
 	/*================== Profile Exception ==================*/
 	@ExceptionHandler(PlannerProfileNotFoundException.class)
-	protected final ResponseEntity<ErrorResponse> handlerPlannerProfileNotFoundException(
+	protected final ApiResponse<Object> handlerPlannerProfileNotFoundException(
 		PlannerProfileNotFoundException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.PLANNER_PROFILE_NOTFOUND, e.getMessage());
 	}
 
 	/*================== Token Exception ==================*/
 	@ExceptionHandler(RefreshTokenNotEqualException.class)
-	protected final ResponseEntity<ErrorResponse> handleRefreshTokenNotEqualException(RefreshTokenNotEqualException e) {
+	protected final ApiResponse<Object> handleRefreshTokenNotEqualException(RefreshTokenNotEqualException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.REFRESH_TOKEN_UNAUTHORIZED, e.getMessage());
 	}
 
 	@ExceptionHandler(UnAuthorizedRefreshTokenException.class)
-	protected final ResponseEntity<ErrorResponse> handlerUnAuthorizedRefreshTokenException(
+	protected final ApiResponse<Object> handlerUnAuthorizedRefreshTokenException(
 		UnAuthorizedRefreshTokenException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.REFRESH_TOKEN_NOTFOUND, e.getMessage());
 	}
 
 	/*================== Portfolio Exception ==================*/
 	@ExceptionHandler(PortfolioNotFoundException.class)
-	protected final ResponseEntity<ErrorResponse> handlePortfolioNotFoundException(PortfolioNotFoundException e) {
+	protected final ApiResponse<Object> handlePortfolioNotFoundException(PortfolioNotFoundException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.PORTFOLIO_NOTFOUND, e.getMessage());
 	}
 
 	@ExceptionHandler(ItemNotFoundException.class)
-	protected final ResponseEntity<ErrorResponse> handleItemNotFoundException(ItemNotFoundException e) {
+	protected final ApiResponse<Object> handleItemNotFoundException(ItemNotFoundException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.ITEM_NOTFOUND, e.getMessage());
 	}
 
 	/*================== Category Exception ==================*/
 	@ExceptionHandler(CategoryNotFoundException.class)
-	protected final ResponseEntity<ErrorResponse> handleCategoryNotFoundException(CategoryNotFoundException e) {
+	protected final ApiResponse<Object> handleCategoryNotFoundException(CategoryNotFoundException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.CATEGORY_NOTFOUND, e.getMessage());
 	}
 
 	/*================== File Exception ==================*/
 	@ExceptionHandler(FileNotFoundException.class)
-	protected final ResponseEntity<ErrorResponse> handleFileNotFoundException(FileNotFoundException e) {
+	protected final ApiResponse<Object> handleFileNotFoundException(FileNotFoundException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.FILE_NOTFOUND, e.getMessage());
 	}
 
 	@ExceptionHandler(FileNameEmptyException.class)
-	protected final ResponseEntity<ErrorResponse> handleFileNameEmptyException(FileNameEmptyException e) {
+	protected final ApiResponse<Object> handleFileNameEmptyException(FileNameEmptyException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.FILE_NAME_EMPTY, e.getMessage());
 	}
 
 	@ExceptionHandler(FileUnSupportedExtensionTypeException.class)
-	protected final ResponseEntity<ErrorResponse> handleUnSupportedExtensionTypeException(
+	protected final ApiResponse<Object> handleUnSupportedExtensionTypeException(
 		FileUnSupportedExtensionTypeException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.FILE_UNSUPPORTED_EXTENSION, e.getMessage());
 	}
 
 	@ExceptionHandler(FileNotImageException.class)
-	protected final ResponseEntity<ErrorResponse> handleFileNotImageException(FileNotImageException e) {
+	protected final ApiResponse<Object> handleFileNotImageException(FileNotImageException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.FILE_NOT_IMAGE, e.getMessage());
 	}
 
 	@ExceptionHandler(FileUploadFailureException.class)
-	protected final ResponseEntity<ErrorResponse> handleFileUploadFailureException(FileUploadFailureException e) {
+	protected final ApiResponse<Object> handleFileUploadFailureException(FileUploadFailureException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.FILE_UPLOAD_FAILURE, e.getMessage());
 	}
 
 	@ExceptionHandler(FileMalformedUrlException.class)
-	protected final ResponseEntity<ErrorResponse> handleFileMalformedUrlException(FileMalformedUrlException e) {
+	protected final ApiResponse<Object> handleFileMalformedUrlException(FileMalformedUrlException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.FILE_MALFORMED_URL, e.getMessage());
 	}
 
 	@ExceptionHandler(FileKakaoProfileDownloadFailureException.class)
-	protected final ResponseEntity<ErrorResponse> handleKakaoProfileDownloadFailureException(FileKakaoProfileDownloadFailureException e) {
+	protected final ApiResponse<Object> handleKakaoProfileDownloadFailureException(FileKakaoProfileDownloadFailureException e) {
 		return ErrorResponse.toErrorResponseEntity(ErrorCode.FILE_KAKAO_PROFILE_DOWNLOAD_FAILURE, e.getMessage());
 	}
 }


### PR DESCRIPTION
### 작업 개요
- 프론트와의 원활한 API 통신을 위해 JSend 기반 API 공통 응답 포맷 생성

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- 성공 시 status (SUCCESS) , data 형식을 리턴
![image](https://github.com/SWM-Space-Odyssey/WeddingMate_BackEnd/assets/68282057/0ca2c7cc-d318-49a0-9591-1687cb0b925e)

- 실패 시 status (FAIL), data 형식을 리턴
![image](https://github.com/SWM-Space-Odyssey/WeddingMate_BackEnd/assets/68282057/0ce6fcc4-e435-40d9-b7cf-e408203ddb5d)

- ErrorResponse도 API 응답 포맷대로 리턴하도록 GlobalExceptionHandler에서 처리했습니다.
- 현재 생성된 API에는 모두 공통 응답 포맷을 적용하였습니다.

### 생각해볼 문제