### PR TITLE
[SO-176] feat: 회원가입 상태 체크 API 추가

### DIFF
--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/controller/SignupController.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/controller/SignupController.java
@@ -4,6 +4,7 @@ import static swmaestro.spaceodyssey.weddingmate.global.constant.ResponseConstan
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,7 +16,10 @@ import swmaestro.spaceodyssey.weddingmate.domain.users.dto.CustomerSignupReqDto;
 import swmaestro.spaceodyssey.weddingmate.domain.users.dto.PlannerSignupReqDto;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.AuthUsers;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
+import swmaestro.spaceodyssey.weddingmate.domain.users.enums.UserRegisterStatusEnum;
 import swmaestro.spaceodyssey.weddingmate.domain.users.service.UsersService;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponse;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponseStatus;
 
 @RestController
 @RequestMapping("/api/v1/signup")
@@ -26,15 +30,31 @@ public class SignupController {
 
 	@PostMapping("/planner")
 	@ResponseStatus(value = HttpStatus.CREATED)
-	public ResponseEntity<String> plannerSignup(@AuthUsers Users users, @RequestBody PlannerSignupReqDto reqDto) {
+	public ApiResponse<Object> plannerSignup(@AuthUsers Users users, @RequestBody PlannerSignupReqDto reqDto) {
 		usersService.signupPlanner(users, reqDto);
-		return ResponseEntity.ok().body(reqDto.getNickname() + PLANNER_SIGNUP_SUCCESS);
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(reqDto.getNickname() + PLANNER_SIGNUP_SUCCESS)
+			.build();
 	}
 
 	@PostMapping("/customer")
 	@ResponseStatus(value = HttpStatus.CREATED)
-	public ResponseEntity<String> customerSignup(@AuthUsers Users users, @RequestBody CustomerSignupReqDto reqDto) {
+	public ApiResponse<Object> customerSignup(@AuthUsers Users users, @RequestBody CustomerSignupReqDto reqDto) {
 		usersService.signupCustomer(users, reqDto);
-		return ResponseEntity.ok().body(reqDto.getNickname() + CUSTOMER_SIGNUP_SUCCESS);
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(reqDto.getNickname() + CUSTOMER_SIGNUP_SUCCESS)
+			.build();
+	}
+
+	@GetMapping()
+	@ResponseStatus(value = HttpStatus.OK)
+	public ApiResponse<Object> checkUserRegisterStatus(@AuthUsers Users users) {
+		UserRegisterStatusEnum userRegisterStatusEnum = usersService.getUserRegisterStatus(users);
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(userRegisterStatusEnum)
+			.build();
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Users.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Users.java
@@ -24,7 +24,8 @@ import swmaestro.spaceodyssey.weddingmate.domain.file.entity.File;
 import swmaestro.spaceodyssey.weddingmate.domain.oauth2.OAuth2UserInfo;
 import swmaestro.spaceodyssey.weddingmate.domain.oauth2.enums.AuthProvider;
 import swmaestro.spaceodyssey.weddingmate.domain.portfolio.entity.Portfolio;
-import swmaestro.spaceodyssey.weddingmate.domain.users.enums.UserEnum;
+import swmaestro.spaceodyssey.weddingmate.domain.users.enums.UserAccountStatusEnum;
+import swmaestro.spaceodyssey.weddingmate.domain.users.enums.UserRegisterStatusEnum;
 import swmaestro.spaceodyssey.weddingmate.global.entity.BaseTimeEntity;
 
 @SuppressWarnings("checkstyle:RegexpMultiline")
@@ -52,7 +53,11 @@ public class Users extends BaseTimeEntity {
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private UserEnum state;
+	private UserRegisterStatusEnum registerStatus;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private UserAccountStatusEnum accountStatus;
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
@@ -87,7 +92,8 @@ public class Users extends BaseTimeEntity {
 		this.profileImage = profileImage;
 		this.authProvider = authProvider;
 		this.authProviderId = authProviderId;
-		this.state = UserEnum.NORMAL;
+		this.registerStatus = UserRegisterStatusEnum.UNREGISTERED;
+		this.accountStatus = UserAccountStatusEnum.NORMAL;
 		this.role = "USER";
 		this.blockCnt = 0;
 		this.reportCnt = 0;
@@ -98,6 +104,10 @@ public class Users extends BaseTimeEntity {
 		this.authProviderId = oAuth2UserInfo.getOAuth2Id();
 
 		return this;
+	}
+
+	public void updateRegisterStatus(UserRegisterStatusEnum registerStatus) {
+		this.registerStatus = registerStatus;
 	}
 
 	public void setPlanner(Planner planner) {

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/enums/UserAccountStatusEnum.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/enums/UserAccountStatusEnum.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
-public enum UserEnum {
+public enum UserAccountStatusEnum {
 	NORMAL("정상"),
 	SUSPENDED("정지"),
 	WITHDRAW("탈퇴"),

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/enums/UserRegisterStatusEnum.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/enums/UserRegisterStatusEnum.java
@@ -1,0 +1,14 @@
+package swmaestro.spaceodyssey.weddingmate.domain.users.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserRegisterStatusEnum {
+	UNREGISTERED("미가입"),
+	PLANNER("플래너"),
+	CUSTOMER("예비부부");
+
+	private String value;
+}


### PR DESCRIPTION
### 작업 개요
회원가입 상태를 확인할 수 있는 API 추가

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경


### 작업 상세 내용
1. 회원 가입 상태를 나타내는 UserRegisterEnum 추가 (UNREGISTERED / PLANNER / CUSTOMER)
- UNREGISTERED : OAuth2 과정을 거쳐 User가 생성되었으나 아직 플래너/예비부부 회원가입을 하지 않은 경우
- PLANNER : OAuth2 & 플래너 회원가입을 완료한 경우
- CUSTOMER : OAuth2 & 예비부부 회원가입을 완료한 경우

![image](https://github.com/SWM-Space-Odyssey/WeddingMate_BackEnd/assets/68282057/a9b88a9c-3baf-4d8c-8263-98fb0e8eec92)

3. 기존 UserEnum을 UserAccountStatusEnum으로 변경
4. 회원 가입 상태 체크 API 생성
(ex. 플래너로 회원가입 한 후)
![image](https://github.com/SWM-Space-Odyssey/WeddingMate_BackEnd/assets/68282057/9e3875a3-931e-4058-ac7a-547251361525)

5. 회원 가입 상태 체크 관련 로직 추가
6. 기존의 중복 회원가입 관련 로직을 UserRegisterEnum을 사용하도록 리팩토링

### 생각해볼 문제