### PR TITLE
[SO-187] feat: 플래너 프로필 태그 수정 추가

### DIFF
--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/controller/MypageProfileController.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/controller/MypageProfileController.java
@@ -21,7 +21,7 @@ import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponseStatus;
 @RestController
 @RequestMapping("/api/v1/profile")
 @RequiredArgsConstructor
-public class UserProfileController {
+public class MypageProfileController {
 
 	private final ProfileService profileService;
 

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/controller/MypageProfileFileUploadController.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/controller/MypageProfileFileUploadController.java
@@ -20,7 +20,7 @@ import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponseStatus;
 @RestController
 @RequestMapping("/api/v1/profile/file")
 @RequiredArgsConstructor
-public class UserProfileFileUploadController {
+public class MypageProfileFileUploadController {
 
 	private final ProfileFileUploadService profileFileUploadService;
 

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/dto/PlannerProfileUpdateReqDto.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/dto/PlannerProfileUpdateReqDto.java
@@ -9,4 +9,5 @@ import lombok.NoArgsConstructor;
 public class PlannerProfileUpdateReqDto {
 	private String bio;
 	private String sns;
+	private String tagList;
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/dto/PlannerProfileUpdateResDto.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/dto/PlannerProfileUpdateResDto.java
@@ -10,10 +10,12 @@ import lombok.NoArgsConstructor;
 public class PlannerProfileUpdateResDto {
 	private String bio;
 	private String sns;
+	private String tagList;
 
 	@Builder
-	public PlannerProfileUpdateResDto(String bio, String sns){
+	public PlannerProfileUpdateResDto(String bio, String sns, String tagList){
 		this.bio = bio;
 		this.sns = sns;
+		this.tagList = tagList;
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/mapper/ProfileMapper.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/mapper/ProfileMapper.java
@@ -36,10 +36,11 @@ public class ProfileMapper {
 			.build();
 	}
 
-	public PlannerProfileUpdateResDto toPlannerProfileUpdateResDto(PlannerProfile plannerProfile) {
+	public PlannerProfileUpdateResDto toPlannerProfileUpdateResDto(PlannerProfile plannerProfile, String tagList) {
 		return PlannerProfileUpdateResDto.builder()
 			.sns(plannerProfile.getSns())
 			.bio(plannerProfile.getBio())
+			.tagList(tagList)
 			.build();
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/service/ProfileService.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/service/ProfileService.java
@@ -52,8 +52,9 @@ public class ProfileService {
 		if (reqDto.getSns() != null) {
 			plannerProfile.updateSns(reqDto.getSns());
 		}
+		planner.updatePlannerTagList(reqDto.getTagList());
 
-		return profileMapper.toPlannerProfileUpdateResDto(plannerProfile);
+		return profileMapper.toPlannerProfileUpdateResDto(plannerProfile, planner.getPlannerTagList());
 	}
 
 	/*================== Repository 접근 ==================*/

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Planner.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Planner.java
@@ -60,4 +60,8 @@ public class Planner extends BaseTimeEntity {
 		this.plannerProfile = plannerProfile;
 		plannerProfile.setPlanner(this);
 	}
+
+	public void updatePlannerTagList(String plannerTagList){
+		this.plannerTagList = plannerTagList;
+	}
 }


### PR DESCRIPTION
### 작업 개요
기존 자기소개, sns에 더불어 프로필 태그까지 수정할 수 있도록 API 변경

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->

### 작업 상세 내용
#### [PUT] /api/v1/profile/planner
> body와 응답에 tagList가 추가되었습니다.
```
{
    "bio": "단 한 번뿐인 웨딩을 누구보다 아름답게, 10년 경력의 플래너입니다.",
    "sns": "@oneandonlywedding",
    "tagList": "열정적인, 열씨미!!"
}
```

```
{
    "status": "SUCCESS",
    "data": {
        "bio": "단 한 번뿐인 웨딩을 누구보다 아름답게, 10년 경력의 플래너입니다.",
        "sns": "@oneandonlywedding",
        "tagList": "열정적인, 열씨미!!"
    }
}
```

### 생각해볼 문제
<!--
  ex) 
  1. wav 파일을 매번 입력하기 귀찮겠다.
-->