### PR TITLE
[SO-195] fix: 유저 프로필 사진이 변경되지 않는 문제 해결

### DIFF
--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/file/service/FileUploadService.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/file/service/FileUploadService.java
@@ -37,6 +37,7 @@ public class FileUploadService {
 		return extractFileNameAndExtension(Objects.requireNonNull(multipartFile.getOriginalFilename()));
 	}
 
+	@Transactional
 	public File uploadFileToS3AndSaveInRepository(final MultipartFile multipartFile, FileInfoDto fileInfoDto,
 		String fileImagePath) {
 		s3Uploader.uploadS3(multipartFile, fileImagePath);
@@ -51,6 +52,7 @@ public class FileUploadService {
 
 	/*================== Basic Upload Service ==================*/
 
+	@Transactional
 	public File createAndSaveFileInRepository(FileInfoDto fileInfoDto, String s3FileName) {
 		File file = File.builder()
 			.filename(fileInfoDto.getFileName())

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/service/ProfileFileUploadService.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/service/ProfileFileUploadService.java
@@ -11,6 +11,7 @@ import swmaestro.spaceodyssey.weddingmate.domain.file.enums.FilePathType;
 import swmaestro.spaceodyssey.weddingmate.domain.file.service.FileService;
 import swmaestro.spaceodyssey.weddingmate.domain.file.service.FileUploadService;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
+import swmaestro.spaceodyssey.weddingmate.domain.users.repository.UsersRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +20,7 @@ public class ProfileFileUploadService {
 
 	private final FileUploadService fileUploadService;
 	private final FileService fileService;
+	private final UsersRepository usersRepository;
 
 	public File createUserProfile(String providerId, String imageUrl) {
 
@@ -29,11 +31,15 @@ public class ProfileFileUploadService {
 		return fileUploadService.uploadImageDataToS3AndSaveInRepository(imageData, fileInfoDto, fileImagePath);
 	}
 
+	@Transactional
 	public String updateProfileFile(Users users, MultipartFile multipartFile) {
 		FileInfoDto fileInfoDto = fileUploadService.validateImageAndExtractFileInfo(multipartFile);
 		String fileImagePath = buildProfileFilePath(fileInfoDto.getFileExtension(), users.getAuthProviderId());
 
 		File file = fileUploadService.uploadFileToS3AndSaveInRepository(multipartFile, fileInfoDto, fileImagePath);
+		users.updateProfileImage(file);
+		usersRepository.save(users);
+
 		return file.getUrl();
 	}
 


### PR DESCRIPTION
### 작업 개요
유저 프로필 사진을 update하는 API에서는 수정된 파일 URL이 잘 반환되나,
프로필을 조회했을 때는 변경사항이 반영되지 않는 오류 해결

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->

### 작업 상세 내용
1. 파일을 s3에 업로드하고 fileRepository에 저장하는 로직은 잘 작동되는 것 체크
2. 해당 파일을 user와 연결하는 로직이 빠져있어 추가

### 생각해볼 문제
<!--
  ex) 
  1. wav 파일을 매번 입력하기 귀찮겠다.
-->