### PR TITLE
[SO-209] 채팅방 CRD & 실시간 채팅 API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,13 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // chat
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.webjars:sockjs-client:1.1.2'
+    implementation 'org.webjars:stomp-websocket:2.3.3-1'
+
     // redis
-    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // S3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,10 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // JSON LocalDateTime
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+
     // chat
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.webjars:sockjs-client:1.1.2'

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/controller/ChatMessageController.java
@@ -1,0 +1,47 @@
+package swmaestro.spaceodyssey.weddingmate.domain.chat.controller;
+
+import java.util.List;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.dto.ChatMessageDto;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.pubsub.RedisPublisher;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.service.ChatMessageService;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.service.ChatRoomService;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponse;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponseStatus;
+
+@RequiredArgsConstructor
+@RestController
+public class ChatMessageController {
+
+	private final RedisPublisher redisPublisher;
+	private final ChatRoomService chatRoomService;
+	private final ChatMessageService chatMessageService;
+
+	// 대화 & 대화 저장
+	@MessageMapping("/chat/message") // /pub/chat/message로 요청해야 함
+	public void sendMessage(@RequestBody ChatMessageDto reqDto) {
+		// 클라이언트의 쪽지방(topic) 입장, 대화를 위해 리스너와 연동
+		chatRoomService.enterChatRoom(reqDto.getRoomId());
+		// Websocket에 발행된 메시지를 redis로 ㅂ라행
+		// 해당 쪽지방을 구독한 클라이언트에게 메시지 전송
+		redisPublisher.publish(chatRoomService.getTopic(reqDto.getRoomId()), reqDto);
+		// DB & redis에 대화 저장
+		chatMessageService.saveMessage(reqDto);
+	}
+
+	@GetMapping("/chat/message/{roomId}")
+	public ApiResponse<Object> getMessageList(@PathVariable String roomId) {
+		List<ChatMessageDto> messageList = chatMessageService.getChatMessageList(roomId);
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(messageList)
+			.build();
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/controller/ChatMessageController.java
@@ -36,7 +36,7 @@ public class ChatMessageController {
 		chatMessageService.saveMessage(reqDto);
 	}
 
-	@GetMapping("/chat/message/{roomId}")
+	@GetMapping("/api/v1/chat/message/{roomId}")
 	public ApiResponse<Object> getMessageList(@PathVariable String roomId) {
 		List<ChatMessageDto> messageList = chatMessageService.getChatMessageList(roomId);
 		return ApiResponse.builder()

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/controller/ChatMessageController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import swmaestro.spaceodyssey.weddingmate.domain.chat.dto.ChatMessageDto;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.dto.ChatMessageResDto;
 import swmaestro.spaceodyssey.weddingmate.domain.chat.pubsub.RedisPublisher;
 import swmaestro.spaceodyssey.weddingmate.domain.chat.service.ChatMessageService;
 import swmaestro.spaceodyssey.weddingmate.domain.chat.service.ChatRoomService;
@@ -38,7 +39,7 @@ public class ChatMessageController {
 
 	@GetMapping("/api/v1/chat/message/{roomId}")
 	public ApiResponse<Object> getMessageList(@PathVariable String roomId) {
-		List<ChatMessageDto> messageList = chatMessageService.getChatMessageList(roomId);
+		List<ChatMessageResDto> messageList = chatMessageService.getChatMessageList(roomId);
 		return ApiResponse.builder()
 			.status(ApiResponseStatus.SUCCESS)
 			.data(messageList)

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/controller/ChatRoomController.java
@@ -1,0 +1,57 @@
+package swmaestro.spaceodyssey.weddingmate.domain.chat.controller;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.dto.ChatMessageReqDto;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.service.ChatRoomService;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.AuthUsers;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponse;
+import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponseStatus;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/chat")
+public class ChatRoomController {
+
+	private final ChatRoomService chatRoomService;
+
+	@PostMapping("/room")
+	public ApiResponse<Object> createRoom(@AuthUsers Users users, @RequestBody ChatMessageReqDto reqDto) {
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(chatRoomService.createRoom(users, reqDto))
+			.build();
+	}
+
+	@GetMapping("/rooms")
+	public ApiResponse<Object> findAllRoomByUser(@AuthUsers Users users) {
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(chatRoomService.findAllRoomByUser(users))
+			.build();
+	}
+
+	@GetMapping("/room/{roomId}")
+	public ApiResponse<Object> findRoomByRoomId(@PathVariable String roomId) {
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(chatRoomService.findRoomByRoomId(roomId))
+			.build();
+	}
+
+	@DeleteMapping("/room/{roomId}")
+	public ApiResponse<Object> deleteRoom(@AuthUsers Users users, @PathVariable String roomId) {
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(chatRoomService.deleteRoom(users, roomId))
+			.build();
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/dto/ChatMessageDto.java
@@ -1,0 +1,25 @@
+package swmaestro.spaceodyssey.weddingmate.domain.chat.dto;
+
+import java.io.Serializable;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.entity.ChatMessage;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessageDto implements Serializable {
+
+	private static final long serialVersionUID = 6494678977089006639L;
+
+	private String roomId;
+	private String sender;
+	private String message;
+
+	public ChatMessageDto(ChatMessage chatMessage) {
+		this.sender = chatMessage.getSender();
+		this.roomId = chatMessage.getRoomId();
+		this.message = chatMessage.getMessage();
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/dto/ChatMessageReqDto.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/dto/ChatMessageReqDto.java
@@ -1,0 +1,16 @@
+package swmaestro.spaceodyssey.weddingmate.domain.chat.dto;
+
+import java.io.Serializable;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessageReqDto implements Serializable {
+
+	private static final long serialVersionUID = 990913L;
+
+	private String receiver; // receiver nickname
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/dto/ChatMessageResDto.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/dto/ChatMessageResDto.java
@@ -1,0 +1,37 @@
+package swmaestro.spaceodyssey.weddingmate.domain.chat.dto;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessageResDto implements Serializable {
+
+	private static final long serialVersionUID = 6494678977089006639L;
+
+	private String roomId;
+	private String sender;
+	private String message;
+
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
+	private LocalDateTime lastMessageTime;
+
+	@Builder
+	public ChatMessageResDto(String roomId, String sender, String message, LocalDateTime lastMessageTime) {
+		this.roomId = roomId;
+		this.sender = sender;
+		this.message = message;
+		this.lastMessageTime = lastMessageTime;
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/dto/ChatRoomDto.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/dto/ChatRoomDto.java
@@ -1,0 +1,52 @@
+package swmaestro.spaceodyssey.weddingmate.domain.chat.dto;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.entity.ChatRoom;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoomDto implements Serializable {
+
+	private static final long serialVersionUID = 6494678977089006639L;
+	private static final String ROOM_NAME_CONNECTOR = "_";
+
+	private String roomName;
+	private String roomId;
+	private String sender;
+	private String receiver;
+	private LocalDateTime lastMessageTime;
+
+	// 쪽지방 생성
+	public static ChatRoomDto create(String senderEmail, String receiverEmail) {
+		return ChatRoomDto.builder()
+			.roomId(UUID.randomUUID().toString())
+			.roomName(senderEmail + ROOM_NAME_CONNECTOR + receiverEmail)
+			.sender(senderEmail)
+			.receiver(receiverEmail)
+			.build();
+	}
+
+	@Builder
+	public ChatRoomDto(String roomName, String roomId, String sender, String receiver) {
+		this.roomName = roomName;
+		this.roomId = roomId;
+		this.sender = sender;
+		this.receiver = receiver;
+	}
+
+	public ChatRoom toEntity() {
+		return ChatRoom.builder()
+			.roomName(this.roomName)
+			.roomId(this.roomId)
+			.sender(this.sender)
+			.receiver(this.receiver)
+			.build();
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/dto/ChatRoomDto.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/dto/ChatRoomDto.java
@@ -4,6 +4,11 @@ import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,6 +26,9 @@ public class ChatRoomDto implements Serializable {
 	private String roomId;
 	private String sender;
 	private String receiver;
+
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
 	private LocalDateTime lastMessageTime;
 
 	// 쪽지방 생성

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/dto/ChatRoomResDto.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/dto/ChatRoomResDto.java
@@ -1,0 +1,42 @@
+package swmaestro.spaceodyssey.weddingmate.domain.chat.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.entity.ChatRoom;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoomResDto {
+	private String roomName;
+	private String roomId;
+	private String sender;
+	private String receiver;
+	private String latestMessage;
+	private LocalDateTime lastMessageTime;
+
+	// 쪽지방 생성
+	public ChatRoomResDto(ChatRoom entity) {
+		this.roomName = entity.getRoomName();
+		this.roomId = entity.getRoomId();
+		this.sender = entity.getSender();
+		this.receiver = entity.getReceiver();
+		this.latestMessage = entity.getChatMessageList().get(0).getMessage();
+		this.lastMessageTime = entity.getLastMessageTime();
+	}
+
+	// 사용자 관련 쪽지방 전체 조회
+	@Builder
+	public ChatRoomResDto(String roomName, String roomId, String sender, String receiver,
+			String latestMessage, LocalDateTime lastMessageTime) {
+		this.roomName = roomName;
+		this.roomId = roomId;
+		this.sender = sender;
+		this.receiver = receiver;
+		this.latestMessage = latestMessage;
+		this.lastMessageTime = lastMessageTime;
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/dto/ChatRoomResDto.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/dto/ChatRoomResDto.java
@@ -2,11 +2,15 @@ package swmaestro.spaceodyssey.weddingmate.domain.chat.dto;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import swmaestro.spaceodyssey.weddingmate.domain.chat.entity.ChatRoom;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -16,17 +20,10 @@ public class ChatRoomResDto {
 	private String sender;
 	private String receiver;
 	private String latestMessage;
-	private LocalDateTime lastMessageTime;
 
-	// 쪽지방 생성
-	public ChatRoomResDto(ChatRoom entity) {
-		this.roomName = entity.getRoomName();
-		this.roomId = entity.getRoomId();
-		this.sender = entity.getSender();
-		this.receiver = entity.getReceiver();
-		this.latestMessage = entity.getChatMessageList().get(0).getMessage();
-		this.lastMessageTime = entity.getLastMessageTime();
-	}
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
+	private LocalDateTime lastMessageTime;
 
 	// 사용자 관련 쪽지방 전체 조회
 	@Builder

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/entity/ChatMessage.java
@@ -12,6 +12,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.dto.ChatMessageReqDto;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.dto.ChatMessageResDto;
 
 @Getter
 @Entity
@@ -39,6 +41,15 @@ public class ChatMessage {
 		this.roomId = roomId;
 		this.message = message;
 		this.lastMessageTime = LocalDateTime.now();
+	}
+
+	public ChatMessageResDto toChatMessageResDto(){
+		return ChatMessageResDto.builder()
+			.roomId(this.roomId)
+			.sender(this.sender)
+			.message(this.message)
+			.lastMessageTime(this.lastMessageTime)
+			.build();
 	}
 
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,44 @@
+package swmaestro.spaceodyssey.weddingmate.domain.chat.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long chatMessageId;
+
+	private String roomId;
+
+	private String sender;
+
+	private String message;
+
+	private LocalDateTime lastMessageTime;
+
+	@ManyToOne
+	@JoinColumn(name = "roomId", referencedColumnName = "roomId", insertable = false, updatable = false)
+	private ChatRoom chatRoom;
+
+	@Builder
+	public ChatMessage(String sender, String roomId, String message) {
+		this.sender = sender;
+		this.roomId = roomId;
+		this.message = message;
+		this.lastMessageTime = LocalDateTime.now();
+	}
+
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/entity/ChatRoom.java
@@ -1,0 +1,74 @@
+package swmaestro.spaceodyssey.weddingmate.domain.chat.entity;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.dto.ChatRoomResDto;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class ChatRoom {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long chatRoomId;
+
+	private String roomName;
+
+	@Column(unique = true)
+	private String roomId;
+
+	private String sender;
+
+	private String receiver;
+
+	@OneToMany(mappedBy = "chatRoom", cascade = CascadeType.REMOVE)
+	private List<ChatMessage> chatMessageList = new ArrayList<>();
+
+	private String lastMessage;
+
+	private LocalDateTime lastMessageTime;
+
+	@Builder
+	public ChatRoom(String roomName, String roomId, String sender, String receiver) {
+		this.roomName = roomName;
+		this.roomId = roomId;
+		this.sender = sender;
+		this.receiver = receiver;
+		this.lastMessageTime = LocalDateTime.now();
+	}
+
+	public ChatRoomResDto toChatRoomResDto() {
+		return ChatRoomResDto.builder()
+			.roomName(this.roomName)
+			.roomId(this.roomId)
+			.sender(this.sender)
+			.receiver(this.receiver)
+			.latestMessage(getLastMessageOrDefault())
+			.lastMessageTime(this.lastMessageTime)
+			.build();
+	}
+
+	public String getLastMessageOrDefault() {
+		return this.chatMessageList.isEmpty() ? "" : this.chatMessageList.get(this.chatMessageList.size() - 1).getMessage();
+	}
+
+	public void updateLastMessage(String lastMessage) {
+		this.lastMessage = lastMessage;
+	}
+	public void updateLastMessageTime(LocalDateTime lastMessageTime) {
+		this.lastMessageTime = lastMessageTime;
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/enums/MessageType.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/enums/MessageType.java
@@ -1,0 +1,5 @@
+package swmaestro.spaceodyssey.weddingmate.domain.chat.enums;
+
+public enum MessageType {
+	ENTER, TALK;
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/pubsub/RedisPublisher.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/pubsub/RedisPublisher.java
@@ -1,0 +1,21 @@
+package swmaestro.spaceodyssey.weddingmate.domain.chat.pubsub;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.dto.ChatMessageDto;
+
+@RequiredArgsConstructor
+@Service
+public class RedisPublisher {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	// Redis Topic에 메시지 발행
+	// 메시지 발행 후, 대기 중이던 redis subscriber가 메시지 처리
+	public void publish(ChannelTopic topic, ChatMessageDto message) {
+		redisTemplate.convertAndSend(topic.getTopic(), message);
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/pubsub/RedisSubscriber.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/pubsub/RedisSubscriber.java
@@ -1,0 +1,40 @@
+package swmaestro.spaceodyssey.weddingmate.domain.chat.pubsub;
+
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.dto.ChatMessageDto;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class RedisSubscriber implements MessageListener {
+
+	private final ObjectMapper objectMapper;
+	private final RedisTemplate redisTemplate;
+	private final SimpMessageSendingOperations messagingTemplate;
+
+	/**
+	 * Redis에서 메시지가 발행(publish)되면 대기하고 있던 onMessage가 해당 메시지를 받아 처리한다.
+	 */
+	@Override
+	public void onMessage(Message message, byte[] pattern) {
+		try {
+			// redis에서 발행된 데이터를 받아 deserialize
+			String publishMessage = (String) redisTemplate.getStringSerializer().deserialize(message.getBody());
+			// ChatMessage 객채로 맵핑
+			ChatMessageDto roomMessage = objectMapper.readValue(publishMessage, ChatMessageDto.class);
+			// Websocket 구독자에게 채팅 메시지 Send
+			messagingTemplate.convertAndSend("/sub/chat/room/" + roomMessage.getRoomId(), roomMessage);
+		} catch (Exception e) {
+			log.error(e.getMessage());
+		}
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,12 @@
+package swmaestro.spaceodyssey.weddingmate.domain.chat.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import swmaestro.spaceodyssey.weddingmate.domain.chat.entity.ChatMessage;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+	List<ChatMessage> findByRoomIdOrderByLastMessageTimeAsc(String roomId);
+	ChatMessage findTopByRoomIdOrderByLastMessageTimeDesc(String roomId);
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,17 @@
+package swmaestro.spaceodyssey.weddingmate.domain.chat.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import swmaestro.spaceodyssey.weddingmate.domain.chat.entity.ChatRoom;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+	@Query("SELECT cr FROM ChatRoom cr WHERE cr.sender = :userEmail OR cr.receiver = :userEmail")
+	List<ChatRoom> findByUserEmail(@Param("userEmail") String userEmail);
+	ChatRoom findBySenderAndReceiver(String sender, String receiver);
+	Optional<ChatRoom> findByRoomId(String roomId);
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/service/ChatMessageService.java
@@ -1,0 +1,51 @@
+package swmaestro.spaceodyssey.weddingmate.domain.chat.service;
+
+import java.util.List;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.dto.ChatMessageDto;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.entity.ChatMessage;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.repository.ChatMessageRepository;
+
+@Slf4j
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService {
+	private final RedisTemplate<String, ChatMessageDto> redisMessageTemplate;
+	private final ChatMessageRepository chatMessageRepository;
+	private final ChatRoomService chatRoomService;
+
+	public void saveMessage(ChatMessageDto dto) {
+		// DB 저장
+		ChatMessage chatMessage = ChatMessage.builder()
+			.roomId(dto.getRoomId())
+			.sender(dto.getSender())
+			.message(dto.getMessage())
+			.build();
+		chatMessageRepository.save(chatMessage);
+
+		// 직렬화
+		redisMessageTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(ChatMessageDto.class));
+
+		// redis 저장 (최신일수록 오른쪽)
+		redisMessageTemplate.opsForList().rightPush(dto.getRoomId(), dto);
+
+		// 채팅방 lastMessageTime 업데이트
+		chatRoomService.updateChatRoomLastMessageAndTime(dto.getRoomId(), chatMessage);
+
+		// 1시간마다 redis에서 메시지 삭제
+		//redisMessageTemplate.expire(dto.getRoomId(), 1, TimeUnit.HOURS);
+	}
+
+	public List<ChatMessageDto> getChatMessageList(String roomId) {
+		// TODO : 메시지 개수 정해서 가져오게 하기
+		return redisMessageTemplate.opsForList().range(roomId, 0, -1);
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/chat/service/ChatRoomService.java
@@ -1,0 +1,164 @@
+package swmaestro.spaceodyssey.weddingmate.domain.chat.service;
+
+import static swmaestro.spaceodyssey.weddingmate.global.constant.ResponseConstant.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.dto.ChatMessageReqDto;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.dto.ChatRoomResDto;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.dto.ChatRoomDto;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.entity.ChatMessage;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.entity.ChatRoom;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.pubsub.RedisSubscriber;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.repository.ChatRoomRepository;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
+import swmaestro.spaceodyssey.weddingmate.domain.users.service.UsersService;
+import swmaestro.spaceodyssey.weddingmate.global.exception.chat.ChatRoomNotAuthorizedException;
+import swmaestro.spaceodyssey.weddingmate.global.exception.chat.ChatRoomNotFoundException;
+
+@Slf4j
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+	private final ChatRoomRepository chatRoomRepository;
+	private final UsersService usersService;
+
+	// 쪽지방(topic)에 발행되는 메시지 처리하는 리스너
+	private final RedisMessageListenerContainer redisMessageListenerContainer;
+
+	// 구독 처리 서비스
+	private final RedisSubscriber redisSubscriber;
+
+	// 1. redis
+	private static final String CHAT_ROOM_PREFIX = "CHAT_ROOM";
+	private final RedisTemplate<String, Object> redisTemplate;
+	private HashOperations<String, String, ChatRoomDto> opsHashChatRoom;
+
+	// 2. 쪽지방 대화 메시지 발행을 위한 redis 쪽지방(topic) 정보
+	private Map<String, ChannelTopic> topicMap;
+
+	// 3. Redis Hash 초기화
+	@PostConstruct
+	private void init() {
+		opsHashChatRoom = redisTemplate.opsForHash();
+		topicMap = new HashMap<>();
+	}
+
+	/*================== Message 관련 함수 ==================*/
+	public void enterChatRoom(String roomId) {
+		topicMap.computeIfAbsent(roomId, key -> {
+			ChannelTopic topic = new ChannelTopic(key);
+			redisMessageListenerContainer.addMessageListener(redisSubscriber, topic);
+			return topic;
+		});
+	}
+
+	public ChannelTopic getTopic(String roomId){
+		return topicMap.get(roomId);
+	}
+
+	@Transactional
+	public void updateChatRoomLastMessageAndTime(String roomId, ChatMessage chatMessage){
+		ChatRoom chatRoom = findByRoomId(roomId);
+		chatRoom.updateLastMessage(chatMessage.getMessage());
+		chatRoom.updateLastMessageTime(chatMessage.getLastMessageTime());
+	}
+
+	/*================== Room CRUD 관련 함수 ==================*/
+	public ChatRoomResDto createRoom(Users users, ChatMessageReqDto reqDto) {
+		String senderEmail = users.getEmail();
+		String receiverEmail = usersService.findUserByNickname(reqDto.getReceiver()).getEmail();
+		ChatRoom chatRoom = findBySenderAndReceiver(senderEmail, receiverEmail);
+
+		// 1) 처음 쪽지방 생성하는 경우
+		if (chatRoom == null) {
+			ChatRoomDto chatRoomDto = ChatRoomDto.create(senderEmail, receiverEmail);
+			opsHashChatRoom.put(CHAT_ROOM_PREFIX, chatRoomDto.getRoomId(),chatRoomDto);
+			chatRoom = chatRoomRepository.save(chatRoomDto.toEntity());
+		}
+
+		return chatRoom.toChatRoomResDto();
+	}
+
+	public List<ChatRoomResDto> findAllRoomByUser(Users users){
+		List<ChatRoom> chatRoomList = findByUserEmail(users.getEmail());
+
+		return chatRoomList.stream()
+			.filter(chatRoom -> {
+				String latestMessage = chatRoom.getLastMessage();
+				return latestMessage != null;
+			})
+			.map(chatRoom -> {
+				String roomName = createRoomName(users, chatRoom);
+
+				return ChatRoomResDto.builder()
+						.roomName(roomName)
+						.roomId(chatRoom.getRoomId())
+						.sender(chatRoom.getSender())
+						.receiver(chatRoom.getReceiver())
+						.latestMessage(chatRoom.getLastMessage())
+						.lastMessageTime(chatRoom.getLastMessageTime())
+						.build();
+			})
+			.toList();
+	}
+
+	public ChatRoomResDto findRoomByRoomId(String roomId) {
+		ChatRoom chatRoom = findByRoomId(roomId);
+
+		return chatRoom.toChatRoomResDto();
+	}
+
+	public String deleteRoom(Users users, String roomId) {
+		ChatRoom chatRoom = findByRoomId(roomId);
+
+		checkUserIsChatRoomOwner(users, chatRoom);
+
+		opsHashChatRoom.delete(CHAT_ROOM_PREFIX, roomId);
+		chatRoomRepository.delete(chatRoom);
+
+		return CHATROOM_DELETE_SUCCESS;
+	}
+
+	/*================== 편의성 함수 ==================*/
+	public String createRoomName(Users users, ChatRoom chatRoom) {
+		String email = users.getEmail().equals(chatRoom.getSender()) ? chatRoom.getReceiver() : chatRoom.getSender();
+		return usersService.findUserByEmail(email).getNickname();
+	}
+
+	public void checkUserIsChatRoomOwner(Users users, ChatRoom chatRoom) {
+		if (!(users.getEmail().equals(chatRoom.getSender()) || users.getEmail().equals(chatRoom.getReceiver()))) {
+			throw new ChatRoomNotAuthorizedException();
+		}
+	}
+
+	/*================== Repository 접근 ==================*/
+	@Transactional(readOnly = true)
+	public ChatRoom findBySenderAndReceiver(String senderEmail, String receiverEmail) {
+		return chatRoomRepository.findBySenderAndReceiver(senderEmail, receiverEmail);
+	}
+
+	@Transactional(readOnly = true)
+	public List<ChatRoom> findByUserEmail(String userEmail) {
+		return chatRoomRepository.findByUserEmail(userEmail);
+	}
+
+	@Transactional(readOnly = true)
+	public ChatRoom findByRoomId(String roomId) {
+		return chatRoomRepository.findByRoomId(roomId)
+			.orElseThrow(ChatRoomNotFoundException::new);
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/service/UsersService.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/service/UsersService.java
@@ -29,6 +29,18 @@ public class UsersService {
 
 	/*================== Repository 접근 ==================*/
 	@Transactional(readOnly = true)
+	public Users findUserById(Long id) {
+		return usersRepository.findById(id)
+			.orElseThrow(UserNotFoundException::new);
+	}
+
+	@Transactional(readOnly = true)
+	public Users findUserByNickname(String nickname) {
+		return usersRepository.findByNickname(nickname)
+			.orElseThrow(UserNotFoundException::new);
+	}
+
+	@Transactional(readOnly = true)
 	public Users findUserByEmail(String email) {
 		return usersRepository.findByEmail(email)
 			.orElseThrow(UserNotFoundException::new);

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/global/config/SecurityConfig.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/global/config/SecurityConfig.java
@@ -65,6 +65,7 @@ public class SecurityConfig {
 		http.authorizeHttpRequests(auth ->
 			auth
 				.requestMatchers("/login/**", "/oauth2/**").permitAll()
+				.requestMatchers("/stomp/**").permitAll()
 				.anyRequest().authenticated()
 		);
 

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/global/config/jackson/JackSonConfig.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/global/config/jackson/JackSonConfig.java
@@ -1,0 +1,18 @@
+package swmaestro.spaceodyssey.weddingmate.global.config.jackson;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+public class JackSonConfig {
+	@Bean
+	public ObjectMapper objectMapper(Jackson2ObjectMapperBuilder builder) {
+		ObjectMapper objectMapper = builder.build();
+		objectMapper.registerModule(new JavaTimeModule()); // Java 8 날짜 및 시간 모듈 등록
+		return objectMapper;
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/global/config/redis/RedisConfig.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/global/config/redis/RedisConfig.java
@@ -11,7 +11,7 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
-import swmaestro.spaceodyssey.weddingmate.domain.chat.dto.ChatMessageDto;
+import swmaestro.spaceodyssey.weddingmate.domain.chat.dto.ChatMessageResDto;
 
 @Configuration
 public class RedisConfig {
@@ -59,11 +59,11 @@ public class RedisConfig {
 	* Redis에 메시지 내역을 저장하기 위한 redisTemplate 설정
 	*/
 	@Bean
-	public RedisTemplate<String, ChatMessageDto> redisMessageTemplate(RedisConnectionFactory connectionFactory) {
-		RedisTemplate<String, ChatMessageDto> redisMessageTemplate = new RedisTemplate<>();
+	public RedisTemplate<String, ChatMessageResDto> redisMessageTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, ChatMessageResDto> redisMessageTemplate = new RedisTemplate<>();
 		redisMessageTemplate.setConnectionFactory(connectionFactory);
 		redisMessageTemplate.setKeySerializer(new StringRedisSerializer());
-		redisMessageTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(ChatMessageDto.class));
+		redisMessageTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(ChatMessageResDto.class));
 
 		return redisMessageTemplate;
 	}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/global/config/redis/RedisConfig.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/global/config/redis/RedisConfig.java
@@ -63,7 +63,7 @@ public class RedisConfig {
 		RedisTemplate<String, ChatMessageDto> redisMessageTemplate = new RedisTemplate<>();
 		redisMessageTemplate.setConnectionFactory(connectionFactory);
 		redisMessageTemplate.setKeySerializer(new StringRedisSerializer());
-		redisMessageTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+		redisMessageTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(ChatMessageDto.class));
 
 		return redisMessageTemplate;
 	}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/global/config/redis/RedisConfig.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/global/config/redis/RedisConfig.java
@@ -7,7 +7,11 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import swmaestro.spaceodyssey.weddingmate.domain.chat.dto.ChatMessageDto;
 
 @Configuration
 public class RedisConfig {
@@ -27,15 +31,40 @@ public class RedisConfig {
 		return new LettuceConnectionFactory(redisStandaloneConfiguration);
 	}
 
+	/**
+	 * redis pub/sub 메시지를 처리하는 listener 설정
+	 */
 	@Bean
-	public RedisTemplate<String, Object> redisTemplate() {
-		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-		redisTemplate.setConnectionFactory(redisConnectionFactory());
-		// 일반적인 문자열 key value의 경우 시리얼라이저 설정
-		// redis-cli로 데이터를 확인할 때 알아볼 수 있는 형태로 표시해준다.
-		redisTemplate.setKeySerializer(new StringRedisSerializer());
-		redisTemplate.setValueSerializer(new StringRedisSerializer());
+	public RedisMessageListenerContainer redisMessageListener(RedisConnectionFactory connectionFactory) {
+		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+		container.setConnectionFactory(connectionFactory);
+		return container;
+	}
 
+	/**
+	 * 어플리케이션에서 사용할 redisTemplate 설정
+	 */
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(connectionFactory);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		// Java 객체를 JSON 형식으로 직렬화하고 역직렬화하는 데 사용
+		// Jackson2JsonRedisSerializer 생성자의 타겟 클래스를 ChatMessage.class로 변경하여 제대로된 직렬화와 역직렬화가 이루어지도록 한다
+		redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
 		return redisTemplate;
+	}
+
+	/*
+	* Redis에 메시지 내역을 저장하기 위한 redisTemplate 설정
+	*/
+	@Bean
+	public RedisTemplate<String, ChatMessageDto> redisMessageTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, ChatMessageDto> redisMessageTemplate = new RedisTemplate<>();
+		redisMessageTemplate.setConnectionFactory(connectionFactory);
+		redisMessageTemplate.setKeySerializer(new StringRedisSerializer());
+		redisMessageTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+
+		return redisMessageTemplate;
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/global/config/stomp/WebSocketConfig.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/global/config/stomp/WebSocketConfig.java
@@ -1,0 +1,28 @@
+package swmaestro.spaceodyssey.weddingmate.global.config.stomp;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry config) {
+		config.enableSimpleBroker("/sub"); // 메시지를 구독하는 요청의 prefix는 sub
+		config.setApplicationDestinationPrefixes("/pub"); // 메시지를 발행하는 요청의 prefix는 pub
+	}
+
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		// socketJs 없을 때 : ws://localhost:8080/stomp
+		// 개발서버 접속 주소 : http://localhost:8080/stomp
+		registry.addEndpoint("/stomp").setAllowedOriginPatterns("*").withSockJS();
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/global/constant/ResponseConstant.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/global/constant/ResponseConstant.java
@@ -35,19 +35,19 @@ public class ResponseConstant {
 	public static final String PROFILE_MODIFICATION_NOT_ALLOWED = "해당 프로필의 작성자가 아닙니다.";
 
 	/* PORTFOLIO */
-	public static final String PORTFOLIO_NOTFOUND = "해당 포트폴리오를 찾을 수 없습니다";
+	public static final String PORTFOLIO_NOTFOUND = "해당 포트폴리오를 찾을 수 없습니다.";
 	public static final String PORTFOLIO_CREATE_SUCCESS = "해당 포트폴리오를 생성했습니다.";
 	public static final String PORTFOLIO_UPDATE_SUCCESS = "해당 포트폴리오를 수정했습니다.";
 	public static final String PORTFOLIO_DELETE_SUCCESS = "해당 포트폴리오를 삭제했습니다.";
 
 	/* ITEM */
-	public static final String ITEM_NOTFOUND = "해당 아이템을 찾을 수 없습니다";
+	public static final String ITEM_NOTFOUND = "해당 아이템을 찾을 수 없습니다.";
 	public static final String ITEM_CREATE_SUCCESS = "해당 아이템을 생성했습니다.";
 	public static final String ITEM_UPDATE_SUCCESS = "해당 아이템을 수정했습니다.";
 	public static final String ITEM_DELETE_SUCCESS = "해당 아이템을 삭제했습니다.";
 
 	/* CATEGORY */
-	public static final String CATEGORY_NOTFOUND = "카테고리를 찾을 수 없습니다";
+	public static final String CATEGORY_NOTFOUND = "카테고리를 찾을 수 없습니다.";
 
 	/* Token */
 	public static final String REFRESH_TOKEN_UNAUTHORIZED = "Refresh Token 검증에 실패했습니다.";
@@ -64,7 +64,12 @@ public class ResponseConstant {
 	public static final String FILE_MALFORMED_URL = "잘못된 파일 URL입니다.";
 
 	/* Like */
-	public static final String LIKE_SUCCESS = "좋아요가 되었습니다";
-	public static final String UNLIKE_SUCCESS = "좋아요가 취소되었습니다";
-	public static final String LIKE_TYPE_NOT_SUPPORTED = "지원되지 않는 좋아요 타입입니다";
+	public static final String LIKE_SUCCESS = "좋아요가 되었습니다.";
+	public static final String UNLIKE_SUCCESS = "좋아요가 취소되었습니다.";
+	public static final String LIKE_TYPE_NOT_SUPPORTED = "지원되지 않는 좋아요 타입입니다.";
+
+	/* CHAT */
+	public static final String CHATROOM_NOTFOUND = "채팅방을 찾을 수 없습니다.";
+	public static final String CHATROOM_DELETE_SUCCESS = "해당 채팅방을 삭제했습니다.";
+	public static final String CHATROOM_NOT_AUTHORIZED = "해당 채팅방의 주인이 아닙니다.";
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/global/exception/chat/ChatRoomNotAuthorizedException.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/global/exception/chat/ChatRoomNotAuthorizedException.java
@@ -1,0 +1,13 @@
+package swmaestro.spaceodyssey.weddingmate.global.exception.chat;
+
+import static swmaestro.spaceodyssey.weddingmate.global.constant.ResponseConstant.*;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class ChatRoomNotAuthorizedException extends RuntimeException{
+	public ChatRoomNotAuthorizedException() {
+		super(CHATROOM_NOT_AUTHORIZED);
+	}
+}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/global/exception/chat/ChatRoomNotFoundException.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/global/exception/chat/ChatRoomNotFoundException.java
@@ -1,0 +1,13 @@
+package swmaestro.spaceodyssey.weddingmate.global.exception.chat;
+
+import static swmaestro.spaceodyssey.weddingmate.global.constant.ResponseConstant.*;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ChatRoomNotFoundException extends RuntimeException {
+	public ChatRoomNotFoundException() {
+		super(CHATROOM_NOTFOUND);
+	}
+}


### PR DESCRIPTION
### 작업 개요
Redis sub/pub 및 Websocket을 이용하여 실시간 채팅 및 채팅방 추가

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->

### 작업 상세 내용
1) Redis에 sub/pub 관련 설정 추가
2) 채팅방 CRD API 추가
3) 실시간 채팅 API 추가
4) 채팅방 메시지 조회 API 추가

### 채팅방 API
#### [POST] /api/v1/chat/room
> 유저와 receiver로 채팅방 생성
```
{
    "receiver": "CSKIM" // 받는 사람 닉네임
}
```

```
{
    "status": "SUCCESS",
    "data": {
        "roomName": "mnjiya500@daum.net_cskim999@kakao.com",
        "roomId": "1d66c126-75cc-4839-9c08-21134adeb637",
        "sender": "mnjiya500@daum.net",
        "receiver": "cskim999@kakao.com",
        "latestMessage": "",
        "lastMessageTime": "2023-09-03T17:48:40.956476"
    }
}
```

#### [GET] /api/v1/chat/rooms
> 유저가 포함된 채팅방 목록 조회
(채팅 없이 채팅방만 만들어진 경우에는 조회되지 않습니다)
```
{
    "status": "SUCCESS",
    "data": [
        {
            "roomName": "CSKIM",
            "roomId": "1d66c126-75cc-4839-9c08-21134adeb637",
            "sender": "mnjiya500@daum.net",
            "receiver": "cskim999@kakao.com",
            "latestMessage": "쮸앤밀",
            "lastMessageTime": "2023-09-03T18:33:23.173679"
        }
    ]
}
```

#### [GET] /api/v1/chat/room/{roomId}
> 채팅방 번호로 채팅방 조회
```
{
    "status": "SUCCESS",
    "data": {
        "roomName": "mnjiya500@daum.net_cskim999@kakao.com",
        "roomId": "1d66c126-75cc-4839-9c08-21134adeb637",
        "sender": "mnjiya500@daum.net",
        "receiver": "cskim999@kakao.com",
        "latestMessage": "더보이즈 이주연입니다",
        "lastMessageTime": "2023-09-03T18:44:14.240123"
    }
}
```

#### [DELETE] /api/v1/chat/room/{roomId}
> 채팅방 번호로 채팅방 삭제

### 채팅 API
#### http://{localhost}/stomp
- subscription URL : /sub/chat/room/{roomId}
- destination Queue : /pub/chat/message
```
{
    "roomId": "1d66c126-75cc-4839-9c08-21134adeb637",
    "sender": "theboys@gmail.com",
    "message": "더보이즈 이주연입니다"
}
```
![image](https://github.com/SWM-Space-Odyssey/WeddingMate_BackEnd/assets/68282057/66a95766-d69c-45a1-8799-591b5e8b368b)

#### [GET] /api/v1/chat/message/{roomId}
> 채팅방 전체 메시지 조회
```
{
    "status": "SUCCESS",
    "data": [
        {
            "roomId": "1d66c126-75cc-4839-9c08-21134adeb637",
            "sender": "mnjiua@gmail.com",
            "message": "투모로우바이투게더 최연준입니다",
            "lastMessageTime": "2023-09-03T19:09:31.3912572"
        },
        {
            "roomId": "1d66c126-75cc-4839-9c08-21134adeb637",
            "sender": "theboys@gmail.com",
            "message": "더보이즈 이현재입니다",
            "lastMessageTime": "2023-09-03T19:10:26.9726419"
        }
    ]
}
```

### 생각해볼 문제
현재는 채팅방 메시지를 전체 조회하고 있지만, 추후에는 개수 제한을 두어야 할 것 같습니다
제가 본 방식은 https://velog.io/@baekgom/WebSocket-Stomp-Redis-%EC%B1%84%ED%8C%85%EB%B0%A9-%EC%9C%A0%EC%A7%80#1-messagedto
[전송] Redis에서는 1시간 후에 삭제되도록 설정 & DB에 저장
[조회] Redis에서 100개 가져오기 -> 만약 없으면 DB에서 100개 가져오기

### 참고 링크
https://velog.io/@baekgom/WebSocket-Stomp-Redis-%EC%B1%84%ED%8C%85%EB%B0%A9-%EC%9C%A0%EC%A7%80#1-messagedto
https://www.daddyprogrammer.org/
테스트 : https://velog.io/@kny8092/Spring-STOMP%EB%A1%9C-%EC%8B%A4%EC%8B%9C%EA%B0%84-%EC%84%9C%EB%B9%84%EC%8A%A4-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0#config-%EC%84%A4%EC%A0%95%ED%8C%8C%EC%9D%BC