### PR TITLE
[SO-232] style: planner, customer 지역 리스트 변수 이름 regionList로 변경

### DIFF
--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/dto/PlannerInfoDto.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/dto/PlannerInfoDto.java
@@ -10,14 +10,14 @@ import lombok.NoArgsConstructor;
 public class PlannerInfoDto {
 	private String company;
 	private String position;
-	private String region;
+	private String regionList;
 	private String tagList;
 
 	@Builder
-	public PlannerInfoDto(String company, String position, String region, String tagList) {
+	public PlannerInfoDto(String company, String position, String regionList, String tagList) {
 		this.company = company;
 		this.position = position;
-		this.region = region;
+		this.regionList = regionList;
 		this.tagList = tagList;
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/dto/CustomerSignupReqDto.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/dto/CustomerSignupReqDto.java
@@ -12,7 +12,7 @@ public class CustomerSignupReqDto {
 	// Customer 관련 속성
 	private Boolean weddingDateConfirmed;
 	private String weddingDate;
-	private String region;
+	private String regionList;
 	private String budget;
 
 	// CustomerTagList 관련 속성

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Customer.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Customer.java
@@ -30,7 +30,7 @@ public class Customer extends BaseTimeEntity {
 
 	private String weddingDate;
 
-	private String region;
+	private String regionList; // 최대 2개
 
 	@NotNull(message = "예산은 필수로 입력되어야 합니다.")
 	private String budget;
@@ -48,9 +48,9 @@ public class Customer extends BaseTimeEntity {
 	private String makeupTagList;
 
 	@Builder
-	public Customer(Boolean weddingDateConfirmed, String region, String budget, CustomerTagListDto customerTagList) {
+	public Customer(Boolean weddingDateConfirmed, String regionList, String budget, CustomerTagListDto customerTagList) {
 		this.weddingDateConfirmed = weddingDateConfirmed;
-		this.region = region;
+		this.regionList = regionList;
 		this.budget = budget;
 		this.portfolioTagList = customerTagList.getPortfolioTagList();
 		this.plannerTagList = customerTagList.getPlannerTagList();

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Planner.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Planner.java
@@ -41,7 +41,7 @@ public class Planner extends BaseTimeEntity {
 	private String position;
 
 	@NotNull(message = "지역은 필수로 입력되어야 합니다.")
-	private String region;
+	private String regionList; // 최대 3개
 
 	@OneToOne(cascade = CascadeType.PERSIST, fetch = FetchType.EAGER)
 	@JoinColumn(name = "profile_id")
@@ -50,15 +50,15 @@ public class Planner extends BaseTimeEntity {
 	@OneToMany(mappedBy = "planner", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Portfolio> portfolioList;
 
-	private String plannerTagList;
+	private String plannerTagList; // 최대 3개
 
 	private Integer likeCount;
 
 	@Builder
-	public Planner(String company, String position, String region, String plannerTagList) {
+	public Planner(String company, String position, String regionList, String plannerTagList) {
 		this.company = company;
 		this.position = position;
-		this.region = region;
+		this.regionList = regionList;
 		this.plannerTagList = plannerTagList;
 		this.likeCount = 0;
 	}
@@ -66,7 +66,7 @@ public class Planner extends BaseTimeEntity {
 	public void updatePlannerInfo(PlannerInfoDto dto) {
 		updateFieldIfNotNull(dto.getCompany(), this::updateCompany);
 		updateFieldIfNotNull(dto.getPosition(), this::updatePosition);
-		updateFieldIfNotNull(dto.getRegion(), this::updateRegion);
+		updateFieldIfNotNull(dto.getRegionList(), this::updateRegionList);
 		updateFieldIfNotNull(dto.getTagList(), this::updatePlannerTagList);
 	}
 
@@ -90,8 +90,8 @@ public class Planner extends BaseTimeEntity {
 		this.position = position;
 	}
 
-	public void updateRegion(String region){
-		this.region = region;
+	public void updateRegionList(String regionList){
+		this.regionList = regionList;
 	}
 
 	public void updatePlannerTagList(String plannerTagList){

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/mapper/CustomerMapper.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/mapper/CustomerMapper.java
@@ -14,7 +14,7 @@ public class CustomerMapper {
 	public Customer toEntity(CustomerSignupReqDto reqDto) {
 		Customer customer =  Customer.builder()
 			.weddingDateConfirmed(reqDto.getWeddingDateConfirmed())
-			.region(reqDto.getRegion())
+			.regionList(reqDto.getRegionList())
 			.budget(reqDto.getBudget())
 			.customerTagList(reqDto.getCustomerTagList())
 			.build();

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/mapper/PlannerMapper.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/mapper/PlannerMapper.java
@@ -17,7 +17,7 @@ public class PlannerMapper {
 		return Planner.builder()
 			.company(reqDto.getCompany())
 			.position(reqDto.getPosition())
-			.region(reqDto.getRegion())
+			.regionList(reqDto.getRegion())
 			.plannerTagList(reqDto.getPlannerTagList())
 			.build();
 	}
@@ -26,7 +26,7 @@ public class PlannerMapper {
 		return PlannerInfoDto.builder()
 			.company(planner.getCompany())
 			.position(planner.getPosition())
-			.region(planner.getRegion())
+			.regionList(planner.getRegionList())
 			.tagList(planner.getPlannerTagList())
 			.build();
 	}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/global/config/test/DummyEntity.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/global/config/test/DummyEntity.java
@@ -27,7 +27,7 @@ public class DummyEntity {
 
 		Planner planner = Planner.builder()
 			.plannerTagList("친절한")
-			.region("서울")
+			.regionList("서울")
 			.company("웨딩웨딩")
 			.position("사원")
 			.build();


### PR DESCRIPTION
### 작업 개요
- planner 지역 태그를 3개까지 받음에 따라 planner, 관련 dto의 region을 regionList로 변경
- customer 지역 태그를 3개까지 받음에 따라 customer, 관련 dto의 region을 regionList로 변경

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->

### 작업 상세 내용
아래 API에서 region -> regionList로 변경
- 플래너 회원가입 API
- 예비부부 회원가입 API
- 플래너 정보 수정 API

### 생각해볼 문제
<!--
  ex) 
  1. wav 파일을 매번 입력하기 귀찮겠다.
-->