### PR TITLE
[SO-247] hotfix : 포트폴리오 디테일에서 플래너 프로필 아이디 반환

### DIFF
--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/mapper/PortfoliosMapper.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/mapper/PortfoliosMapper.java
@@ -45,7 +45,7 @@ public class PortfoliosMapper {
 			.itemResDtoList(itemResDtoList)
 			.repImgUrl(portfolios.getFiles().getUrl())
 			.isWriter(isWriter)
-			.plannerId(portfolios.getPlanners().getPlannerId())
+			.plannerId(portfolios.getPlanners().getPlannerProfiles().getPlannerProfileId())
 			.isLiked(isPortfolioLiked)
 			.build();
 	}


### PR DESCRIPTION
### 작업 개요
- portfolioDetail에서 plannerProfileId 반환
<!--
  ex) 고양이가 야옹 소리를 내도록 수정
-->

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->

### 작업 상세 내용
1. 그동안은 포트폴리오 디테일에서 플래너 아이디를 반환 중
2. 하지만 플래너 디테일에서 요구하는 id 값은 플래너 프로필 아이디이기 때문에 이를 수정
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  3. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->

### 생각해볼 문제
<!--
  ex) 
  1. wav 파일을 매번 입력하기 귀찮겠다.
-->