### PR TITLE
[SO-248] hotfix : 삭제된 아이템의 피드 이미지 제외

### DIFF
--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/file/repository/FilesRepository.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/file/repository/FilesRepository.java
@@ -15,7 +15,7 @@ public interface FilesRepository extends JpaRepository<Files, Long> {
 
 	List<Files> findByItems(Items items);
 
-	@Query(value = "SELECT * FROM files WHERE file_id > :cursor AND item_id IS NOT NULL ORDER BY file_id ASC LIMIT :limit", nativeQuery = true)
+	@Query(value = "SELECT f.* FROM files f INNER JOIN items i ON f.item_id = i.item_id WHERE f.file_id > :cursor AND i.is_deleted = false LIMIT :limit", nativeQuery = true)
 	List<Files> findFilesAfterCursor(@Param("cursor") Long cursor, @Param("limit") int limit);
 
 	@Query(value = "SELECT MAX(fileId) FROM Files")


### PR DESCRIPTION
### 작업 개요
- 삭제된 아이템의 피드 이미지 제외
<!--
  ex) 고양이가 야옹 소리를 내도록 수정
-->

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->

### 작업 상세 내용
- files와 items를 item_id로 innerjoin 하여 items에서 is_delete가 False인 애들만 가져오게끔 변경
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->

### 생각해볼 문제
<!--
  ex) 
  1. wav 파일을 매번 입력하기 귀찮겠다.
-->