### PR TITLE
[SO-265] fix : redirect url 환경변수로 분리

### DIFF
--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
@@ -33,6 +33,9 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 	private final RedisService redisService;
 	private final CookieAuthorizationRequestRepository cookieAuthorizationRequestRepository;
 
+	@Value("${LOGIN_REDIRECT_URL}")
+	private String loginRedirectUrl;
+
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
 		Authentication authentication) throws IOException, ServletException {
@@ -69,7 +72,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
 	private String makeRedirectUrl(String email, String redirectUrl) {
 		if (redirectUrl.equals(getDefaultTargetUrl())) {
-			redirectUrl = "https://dev.weddingmate.co.kr";
+			redirectUrl = loginRedirectUrl;
 		}
 
 		String accessToken = tokenProvider.createAccessToken(email);

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
@@ -69,7 +69,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
 	private String makeRedirectUrl(String email, String redirectUrl) {
 		if (redirectUrl.equals(getDefaultTargetUrl())) {
-			redirectUrl = "https://weddingmate.co.kr";
+			redirectUrl = "https://dev.weddingmate.co.kr";
 		}
 
 		String accessToken = tokenProvider.createAccessToken(email);

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/global/config/SecurityConfig.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/global/config/SecurityConfig.java
@@ -104,6 +104,7 @@ public class SecurityConfig {
 		configuration.addAllowedOrigin("http://weddingmate-fe-bucket.s3-website.ap-northeast-2.amazonaws.com");
 		configuration.addAllowedOrigin("http://localhost:5173");
 		configuration.addAllowedOrigin("https://weddingmate.co.kr");
+		configuration.addAllowedOrigin("https://dev.weddingmate.co.kr");
 		configuration.setAllowCredentials(true); // 클라이언트에서 쿠키 요청 허용
 		configuration.setAllowedOriginPatterns(Collections.singletonList("*")); // 모든 IP 주소 허용 (프론트엔드 IP, react만 허용) 핸드폰은 js 요청을 하지 않고 java나 swift 쓰기 때문에 cors에 안 걸림
 		configuration.setMaxAge(MAX_AGE_SECS);


### PR DESCRIPTION
### 작업 개요
- 기존에 redirect url이 String 값으로 메인 도메인에 할당되어 있었음
- 하지만 개발서버와 운영서버를 분리하여 이것을 변경할 필요가 있어짐
- redirect_url의 주소를 env.properties에 넣어 이를 받아오는 방식으로 변경
<!--
  ex) 고양이가 야옹 소리를 내도록 수정
-->

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->

### 작업 상세 내용
1. merge 전에 github secrets 변경 필요
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  3. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->

### 생각해볼 문제
- 쿠키에 사용하는 도메인은 host에 서브 도메인은 포함되지 않기 때문에 변경하지 않았습니다. 하지만 혹시 모르니 변경이 필요할 것 같은지 확인 부탁드려요!
<!--
  ex) 
  1. wav 파일을 매번 입력하기 귀찮겠다.
-->