### PR TITLE
[SO-267] fix: userlike에 is_deleted 관련 로직 추가

### DIFF
--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/like/entity/UserLikes.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/like/entity/UserLikes.java
@@ -1,5 +1,8 @@
 package swmaestro.spaceodyssey.weddingmate.domain.like.entity;
 
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -19,6 +22,8 @@ import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
 @Entity
 @Getter
 @NoArgsConstructor
+@SQLDelete(sql = "UPDATE user_likes SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 public class UserLikes {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,6 +31,7 @@ public class UserLikes {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
+	@Where(clause = "account_status = 'NORMAL'")
 	private Users users;
 
 	@Enumerated(EnumType.STRING) // Enum 타입으로 저장되도록 설정
@@ -35,10 +41,17 @@ public class UserLikes {
 	@Column(nullable = false)
 	private Long likedId; // 해당 유형의 테이블의 주 키와 연결
 
+	@Column(nullable = false)
+	private Boolean isDeleted;
+
 	@Builder
 	public UserLikes(Users users, LikeEnum likeEnum, Long likedId) {
 		this.users = users;
 		this.likeType = likeEnum;
 		this.likedId = likedId;
+	}
+
+	public void deleteUserLikes() {
+		this.isDeleted = true;
 	}
 }


### PR DESCRIPTION
### 작업 개요
회원 탈퇴 기능 개발 중 is_deleted column이 DB에 생성되었으나, 관련 코드가 완성되지 않아 is_deleted 값이 초기화되지 않는 문제 발생
 
### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->

### 작업 상세 내용
- entity 관련된 코드만 먼저 커밋하는 방식으로 해결

### 생각해볼 문제
<!--
  ex) 
  1. wav 파일을 매번 입력하기 귀찮겠다.
-->