### PR TITLE
[SO-141] feat: soft delete로 회원 탈퇴 구현

### DIFF
--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/file/entity/Files.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/file/entity/Files.java
@@ -41,17 +41,18 @@ public class Files extends BaseTimeEntity {
 	@JoinColumn(name = "item_id")
 	private Items items;
 
+	@Column(nullable = false)
 	private Boolean isDeleted = false;
-
-	public void setItems(Items items) {
-		this.items = items;
-	}
 
 	@Builder
 	public Files(String filename, String filetype, String url) {
 		this.filename = filename;
 		this.filetype = filetype;
 		this.url = url;
+	}
+
+	public void setItems(Items items) {
+		this.items = items;
 	}
 
 	public void deleteFile() {

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/file/entity/Files.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/file/entity/Files.java
@@ -41,9 +41,7 @@ public class Files extends BaseTimeEntity {
 	@JoinColumn(name = "item_id")
 	private Items items;
 
-	@Column(nullable = false)
-	private Boolean isDeleted;
-
+	private Boolean isDeleted = false;
 
 	public void setItems(Items items) {
 		this.items = items;
@@ -54,7 +52,6 @@ public class Files extends BaseTimeEntity {
 		this.filename = filename;
 		this.filetype = filetype;
 		this.url = url;
-		this.isDeleted = false;
 	}
 
 	public void deleteFile() {

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/item/entity/Items.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/item/entity/Items.java
@@ -2,7 +2,9 @@ package swmaestro.spaceodyssey.weddingmate.domain.item.entity;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -27,6 +29,8 @@ import swmaestro.spaceodyssey.weddingmate.global.entity.BaseTimeEntity;
 @Getter
 @NoArgsConstructor
 @Entity
+@SQLDelete(sql = "UPDATE items SET is_deleted = true WHERE file_id = ?")
+@Where(clause = "is_deleted = false")
 public class Items extends BaseTimeEntity {
 
 	@Id
@@ -53,27 +57,26 @@ public class Items extends BaseTimeEntity {
 	private String category;
 
 	@Column(nullable = false)
-	private Boolean isDeleted;
+	private Boolean isDeleted = false;
 
 	@OneToMany(mappedBy = "items", cascade = CascadeType.PERSIST)
 	private List<Files> filesList = new ArrayList<>();
 
-	private Integer likeCount;
+	private Integer likeCount = 0;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "company_id")
 	private Companies companies;
 
 	@Builder
-	public Items(String itemRecord, String itemTagList, String itemDate, Integer itemOrder, Portfolios portfolios, String category) {
+	public Items(String itemRecord, String itemTagList, String itemDate, Integer itemOrder, Portfolios portfolios,
+		String category) {
 		this.itemRecord = itemRecord;
 		this.itemTagList = itemTagList;
 		this.itemDate = itemDate;
 		this.itemOrder = itemOrder;
 		this.portfolios = portfolios;
 		this.category = category;
-		this.isDeleted = false;
-		this.likeCount = 0;
 	}
 
 	/*================== 기존 필드값 수정 ==================*/
@@ -102,11 +105,5 @@ public class Items extends BaseTimeEntity {
 
 	public void setLikeCount(Integer likeCount) {
 		this.likeCount = likeCount;
-	}
-
-	private void updateFieldIfNotNull(String newValue, Consumer<String> fieldUpdater) {
-		if (newValue != null) {
-			fieldUpdater.accept(newValue);
-		}
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/item/repository/ItemsRepository.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/item/repository/ItemsRepository.java
@@ -3,9 +3,10 @@ package swmaestro.spaceodyssey.weddingmate.domain.item.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-import io.lettuce.core.dynamic.annotation.Param;
 import swmaestro.spaceodyssey.weddingmate.domain.item.entity.Items;
 
 public interface ItemsRepository extends JpaRepository<Items, Long> {
@@ -16,4 +17,11 @@ public interface ItemsRepository extends JpaRepository<Items, Long> {
 		nativeQuery = true)
 	List<Items> searchItemsByKeyword(@Param("keyword") String keyword);
 
+	@Modifying
+	@Query("UPDATE Items item SET item.isDeleted = true WHERE item IN (SELECT item FROM Portfolios p JOIN p.users u WHERE u.userId = :userId)")
+	void softDeleteItemsByUserId(@Param("userId") Long userId);
+
+	@Modifying
+	@Query("UPDATE Items item SET item.isDeleted = true WHERE item.portfolios.portfolioId = :portfolioId")
+	void softDeleteItemByPortfolioId(@Param("portfolioId") Long portfolioId);
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/item/service/ItemsService.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/item/service/ItemsService.java
@@ -12,8 +12,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import swmaestro.spaceodyssey.weddingmate.domain.company.entity.Companies;
 import swmaestro.spaceodyssey.weddingmate.domain.company.service.CompaniesService;
-import swmaestro.spaceodyssey.weddingmate.domain.file.entity.Files;
-import swmaestro.spaceodyssey.weddingmate.domain.file.repository.FilesRepository;
+import swmaestro.spaceodyssey.weddingmate.domain.file.service.FilesRepositoryService;
 import swmaestro.spaceodyssey.weddingmate.domain.item.dto.ItemSearchResDto;
 import swmaestro.spaceodyssey.weddingmate.domain.item.entity.Items;
 import swmaestro.spaceodyssey.weddingmate.domain.item.mapper.ItemsMapper;
@@ -22,14 +21,9 @@ import swmaestro.spaceodyssey.weddingmate.domain.item.dto.ItemSaveReqDto;
 import swmaestro.spaceodyssey.weddingmate.domain.item.dto.ItemUpdateReqDto;
 import swmaestro.spaceodyssey.weddingmate.domain.portfolio.entity.Portfolios;
 import swmaestro.spaceodyssey.weddingmate.domain.item.repository.ItemsRepository;
-import swmaestro.spaceodyssey.weddingmate.domain.portfolio.repository.PortfoliosRepository;
-import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Planners;
+import swmaestro.spaceodyssey.weddingmate.domain.portfolio.service.PortfolioRepositoryService;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
-import swmaestro.spaceodyssey.weddingmate.domain.users.repository.PlannersRepository;
-import swmaestro.spaceodyssey.weddingmate.global.exception.file.FileNotFoundException;
 import swmaestro.spaceodyssey.weddingmate.global.exception.portfolio.ItemNotFoundException;
-import swmaestro.spaceodyssey.weddingmate.global.exception.portfolio.PortfolioNotFoundException;
-import swmaestro.spaceodyssey.weddingmate.global.exception.users.PlannerNotFoundException;
 import swmaestro.spaceodyssey.weddingmate.global.exception.users.UserUnAuthorizedException;
 
 @Service
@@ -39,23 +33,27 @@ public class ItemsService {
 	private final CompaniesService companiesService;
 
 	private final ItemsRepository itemsRepository;
-	private final PortfoliosRepository portfoliosRepository;
-	private final FilesRepository fileRepository;
-	private final PlannersRepository plannersRepository;
+	private final ItemsRepositoryService itemsRepositoryService;
+	private final PortfolioRepositoryService portfolioRepositoryService;
+	private final FilesRepositoryService filesRepositoryService;
 
 	private final ItemsMapper itemsMapper;
 
 	/*================== 아이템 생성 ==================*/
 	public void createItem(ItemSaveReqDto itemSaveReqDto) {
-		Portfolios portfolios = findPortfolioById(itemSaveReqDto.getPortfolioId());
+		Portfolios portfolios = portfolioRepositoryService.findPortfolioById(itemSaveReqDto.getPortfolioId());
 
 		Items items = itemsMapper.dtoToEntity(portfolios, itemSaveReqDto);
 
 		itemsRepository.save(items);
 
 		setItemCompanies(items, itemSaveReqDto);
-
 		setItemImages(items, itemSaveReqDto);
+
+		itemSaveReqDto.getImageList()
+			.stream()
+			.map(filesRepositoryService::findFileByUrl)
+			.forEach(file -> file.setItems(items));
 	}
 
 	private void setItemCompanies(Items items, ItemSaveReqDto itemSaveReqDto) {
@@ -76,17 +74,16 @@ public class ItemsService {
 		// 이미지 정보 업데이트
 		itemSaveReqDto.getImageList()
 			.stream()
-			.map(this::findFileByUrl)
+			.map(filesRepositoryService::findFileByUrl)
 			.forEach(file -> file.setItems(items));
 	}
 
 	/*================== 아이템 업데이트 ==================*/
 	public void updateItem(Users users, Long itemId, ItemUpdateReqDto itemUpdateReqDto) {
-		Items items = findItemById(itemId);
+		Items items = itemsRepositoryService.findItemById(itemId);
 
 		updateItemFields(items, itemUpdateReqDto);
 
-		checkItemDeleted(items);
 		verifyUserIsWriter(items, users);
 
 		updateItemImages(items, itemUpdateReqDto);
@@ -114,13 +111,13 @@ public class ItemsService {
 		// 이미지 정보 업데이트 로직
 		items.getFilesList().forEach(file -> file.setItems(null));
 		itemUpdateReqDto.getImageList().stream()
-			.map(this::findFileByUrl)
+			.map(filesRepositoryService::findFileByUrl)
 			.forEach(file -> file.setItems(items));
 	}
 
 	/*================== 그 외 함수들 ==================*/
 	public ItemResDto findById(Users users, Long id) {
-		Items items = findItemById(id);
+		Items items = itemsRepositoryService.findItemById(id);
 
 		checkItemDeleted(items);
 
@@ -130,9 +127,7 @@ public class ItemsService {
 	}
 
 	public void deleteItem(Users users, Long itemId) {
-		Items items = findItemById(itemId);
-
-		checkItemDeleted(items);
+		Items items = itemsRepositoryService.findItemById(itemId);
 
 		verifyUserIsWriter(items, users);
 
@@ -148,31 +143,10 @@ public class ItemsService {
 		}
 
 		List<ItemSearchResDto> itemSearchResDtoList = itemsList.stream().map(itemsMapper::entityToDto).toList();
-		int start = (int) pageable.getOffset();
+		int start = (int)pageable.getOffset();
 		int end = Math.min((start + pageable.getPageSize()), itemSearchResDtoList.size());
 
 		return new PageImpl<>(itemSearchResDtoList.subList(start, end), pageable, itemSearchResDtoList.size());
-	}
-
-	/*================== Repository 접근 ==================*/
-	public Items findItemById(Long id) {
-		return itemsRepository.findById(id)
-			.orElseThrow(ItemNotFoundException::new);
-	}
-
-	public Portfolios findPortfolioById(Long id) {
-		return portfoliosRepository.findById(id)
-			.orElseThrow(PortfolioNotFoundException::new);
-	}
-
-	public Files findFileByUrl(String url) {
-		return fileRepository.findByUrl(url)
-			.orElseThrow(FileNotFoundException::new);
-	}
-
-	public Planners findPlannerByUsers(Users users) {
-		return plannersRepository.findByUsers(users)
-			.orElseThrow(PlannerNotFoundException::new);
 	}
 
 	/*================== 예외 처리 ==================*/
@@ -182,6 +156,7 @@ public class ItemsService {
 			throw new ItemNotFoundException();
 		}
 	}
+
 	public void verifyUserIsWriter(Items items, Users users) {
 		if (!items.getPortfolios().getUsers().getUserId().equals(users.getUserId())) {
 			throw new UserUnAuthorizedException();

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/like/entity/UserLikes.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/like/entity/UserLikes.java
@@ -42,14 +42,13 @@ public class UserLikes {
 	private Long likedId; // 해당 유형의 테이블의 주 키와 연결
 
 	@Column(nullable = false)
-	private Boolean isDeleted;
+	private Boolean isDeleted = false;
 
 	@Builder
 	public UserLikes(Users users, LikeEnum likeEnum, Long likedId) {
 		this.users = users;
 		this.likeType = likeEnum;
 		this.likedId = likedId;
-		this.isDeleted = false;
 	}
 
 	public void deleteUserLikes() {

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/like/enums/LikeEnum.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/like/enums/LikeEnum.java
@@ -1,6 +1,7 @@
 package swmaestro.spaceodyssey.weddingmate.domain.like.enums;
 
 public enum LikeEnum {
+	COMPANY,
 	PORTFOLIO,
 	ITEM,
 	PLANNER,

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/like/service/LikesService.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/like/service/LikesService.java
@@ -8,24 +8,23 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import swmaestro.spaceodyssey.weddingmate.domain.company.entity.Companies;
 import swmaestro.spaceodyssey.weddingmate.domain.company.repository.CompaniesRepository;
+import swmaestro.spaceodyssey.weddingmate.domain.company.service.CompaniesRepositoryService;
 import swmaestro.spaceodyssey.weddingmate.domain.item.entity.Items;
 import swmaestro.spaceodyssey.weddingmate.domain.item.repository.ItemsRepository;
+import swmaestro.spaceodyssey.weddingmate.domain.item.service.ItemsRepositoryService;
 import swmaestro.spaceodyssey.weddingmate.domain.like.dto.CompanyLikeResDto;
 import swmaestro.spaceodyssey.weddingmate.domain.like.dto.PlannerLikeResDto;
 import swmaestro.spaceodyssey.weddingmate.domain.like.dto.PortfolioLikeResDto;
 import swmaestro.spaceodyssey.weddingmate.domain.like.entity.UserLikes;
 import swmaestro.spaceodyssey.weddingmate.domain.like.enums.LikeEnum;
 import swmaestro.spaceodyssey.weddingmate.domain.like.mapper.LikesMapper;
-import swmaestro.spaceodyssey.weddingmate.domain.like.repository.LikesRepository;
 import swmaestro.spaceodyssey.weddingmate.domain.portfolio.entity.Portfolios;
 import swmaestro.spaceodyssey.weddingmate.domain.portfolio.repository.PortfoliosRepository;
+import swmaestro.spaceodyssey.weddingmate.domain.portfolio.service.PortfolioRepositoryService;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Planners;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
 import swmaestro.spaceodyssey.weddingmate.domain.users.repository.PlannersRepository;
-import swmaestro.spaceodyssey.weddingmate.global.exception.company.CompanyNotFoundException;
-import swmaestro.spaceodyssey.weddingmate.global.exception.portfolio.ItemNotFoundException;
-import swmaestro.spaceodyssey.weddingmate.global.exception.portfolio.PortfolioNotFoundException;
-import swmaestro.spaceodyssey.weddingmate.global.exception.users.PlannerNotFoundException;
+import swmaestro.spaceodyssey.weddingmate.domain.users.service.repositoryservice.PlannersRepositoryService;
 
 @Transactional
 @Service
@@ -33,23 +32,27 @@ import swmaestro.spaceodyssey.weddingmate.global.exception.users.PlannerNotFound
 public class LikesService {
 
 	private final LikesMapper likesMapper;
-	private final LikesRepository likeRepository;
+	private final LikesRepositoryService likesRepositoryService;
+	private final PortfolioRepositoryService portfolioRepositoryService;
+	private final PlannersRepositoryService plannersRepositoryService;
+	private final ItemsRepositoryService itemsRepositoryService;
+	private final CompaniesRepositoryService companiesRepositoryService;
+
 	private final PlannersRepository plannersRepository;
 	private final PortfoliosRepository portfoliosRepository;
 	private final ItemsRepository itemsRepository;
 	private final CompaniesRepository companiesRepository;
 
-
 	public boolean like(Long id, Users users, LikeEnum likeEnum) {
-		List<UserLikes> likeList = getLikesByUsersAndTypeAndId(users, likeEnum, id);
+		List<UserLikes> likeList = likesRepositoryService.getLikesByUsersAndTypeAndId(users, likeEnum, id);
 
 		if (likeList.isEmpty()) {
-			saveLike(users, id, likeEnum);
+			likesRepositoryService.saveLike(users, id, likeEnum);
 			updateLikeCount(id, likeEnum, true);
 			return true;
 		}
 
-		deleteLike(users, id, likeEnum);
+		likesRepositoryService.deleteLike(users, id, likeEnum);
 		updateLikeCount(id, likeEnum, false);
 		return false;
 	}
@@ -58,20 +61,20 @@ public class LikesService {
 	/*================== User가 좋아요 한 Entity 리스트 반환 ==================*/
 
 	public List<PortfolioLikeResDto> getUserLikedPortfolio(Users users) {
-		List<UserLikes> likeList = getLikesByUsersAndType(users, LikeEnum.PORTFOLIO);
+		List<UserLikes> likeList = likesRepositoryService.getLikesByUsersAndType(users, LikeEnum.PORTFOLIO);
 
 		return likeList.stream()
-			.map(userLikes -> findPortfolioById(userLikes.getLikedId()))
+			.map(userLikes -> portfolioRepositoryService.findPortfolioById(userLikes.getLikedId()))
 			.filter(portfolio -> (Boolean.FALSE.equals(portfolio.getIsDeleted())))
 			.map(likesMapper::entityToDto)
 			.toList();
 	}
 
 	public List<PortfolioLikeResDto> getUserLikedItem(Users users) {
-		List<UserLikes> likeList = getLikesByUsersAndType(users, LikeEnum.ITEM);
+		List<UserLikes> likeList = likesRepositoryService.getLikesByUsersAndType(users, LikeEnum.ITEM);
 
 		return likeList.stream()
-			.map(userLikes -> findItemById(userLikes.getLikedId()))
+			.map(userLikes -> itemsRepositoryService.findItemById(userLikes.getLikedId()))
 			.filter(item -> (Boolean.FALSE.equals(item.getIsDeleted())))
 			.map(likesMapper::entityToDto)
 			.toList();
@@ -79,21 +82,24 @@ public class LikesService {
 
 	public List<PlannerLikeResDto> getUserLikedPlanner(Users users) {
 
-		List<UserLikes> likeList = getLikesByUsersAndType(users, LikeEnum.PLANNER);
+		List<UserLikes> likeList = likesRepositoryService.getLikesByUsersAndType(users, LikeEnum.PLANNER);
 
 		return likeList.stream()
-			.map(userLikes -> findPlannerById(userLikes.getLikedId()))
+			.map(userLikes -> plannersRepositoryService.findPlannerById(userLikes.getLikedId()))
 			.map(likesMapper::entityToDto)
 			.toList();
 	}
 
 	public List<CompanyLikeResDto> getUserLikedCompany(Users users) {
 
-		List<UserLikes> likeList = getLikesByUsersAndType(users, LikeEnum.COMPANY);
+		List<UserLikes> likeList = likesRepositoryService.getLikesByUsersAndType(users, LikeEnum.COMPANY);
 
 		return likeList.stream()
-			.map(userLikes -> findCompanyById(userLikes.getLikedId()))
-			.map(likesMapper::entityToDto)
+			.map(userLikes -> {
+				Long companyId = userLikes.getLikedId();
+				Companies company = companiesRepositoryService.findCompanyById(companyId);
+				return likesMapper.entityToDto(company);
+			})
 			.toList();
 	}
 
@@ -110,7 +116,7 @@ public class LikesService {
 
 	private void updatePortfolioLikeCount(Long id, boolean isIncrement) {
 
-		Portfolios portfolios = findPortfolioById(id);
+		Portfolios portfolios = portfolioRepositoryService.findPortfolioById(id);
 
 		if (portfolios != null) {
 			if (isIncrement) {
@@ -124,7 +130,7 @@ public class LikesService {
 
 	private void updateItemLikeCount(Long id, boolean isIncrement) {
 
-		Items items = findItemById(id);
+		Items items = itemsRepositoryService.findItemById(id);
 
 		if (items != null) {
 			if (isIncrement) {
@@ -138,7 +144,7 @@ public class LikesService {
 
 	private void updatePlannerLikeCount(Long id, boolean isIncrement) {
 
-		Planners planners = findPlannerById(id);
+		Planners planners = plannersRepositoryService.findPlannerById(id);
 
 		if (planners != null) {
 			if (isIncrement) {
@@ -152,7 +158,7 @@ public class LikesService {
 
 	private void updateCompanyLikeCount(Long id, boolean isIncrement) {
 
-		Companies companies = findCompanyById(id);
+		Companies companies = companiesRepositoryService.findCompanyById(id);
 
 		if (companies != null) {
 			if (isIncrement) {
@@ -162,44 +168,6 @@ public class LikesService {
 			}
 			companiesRepository.save(companies);
 		}
-	}
-
-	/*================== Repository 접근 ==================*/
-	private List<UserLikes> getLikesByUsersAndTypeAndId(Users users, LikeEnum likeEnum, Long id) {
-		return likeRepository.findByUsersAndLikeTypeAndLikedId(users, likeEnum, id);
-	}
-
-	public List<UserLikes> getLikesByUsersAndType(Users users, LikeEnum likeType) {
-		return likeRepository.findByUsersAndLikeType(users, likeType);
-	}
-
-	private void saveLike(Users users, Long id, LikeEnum likeEnum) {
-		UserLikes like = UserLikes.builder().users(users).likedId(id).likeEnum(likeEnum).build();
-		likeRepository.save(like);
-	}
-
-	private void deleteLike(Users users, Long id, LikeEnum likeEnum) {
-		likeRepository.deleteByUsersAndLikeTypeAndLikedId(users, likeEnum, id);
-	}
-
-	public Planners findPlannerById(Long id) {
-		return plannersRepository.findById(id)
-			.orElseThrow(PlannerNotFoundException::new);
-	}
-
-	public Portfolios findPortfolioById(Long id) {
-		return portfoliosRepository.findById(id)
-			.orElseThrow(PortfolioNotFoundException::new);
-	}
-
-	public Items findItemById(Long id) {
-		return itemsRepository.findById(id)
-			.orElseThrow(ItemNotFoundException::new);
-	}
-
-	public Companies findCompanyById(Long id) {
-		return companiesRepository.findById(id)
-			.orElseThrow(CompanyNotFoundException::new);
 	}
 }
 

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/entity/Portfolios.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/entity/Portfolios.java
@@ -3,6 +3,9 @@ package swmaestro.spaceodyssey.weddingmate.domain.portfolio.entity;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -26,6 +29,8 @@ import swmaestro.spaceodyssey.weddingmate.global.entity.BaseTimeEntity;
 @NoArgsConstructor
 @Getter
 @Entity
+@SQLDelete(sql = "UPDATE portfolios SET is_deleted = true WHERE portfolio_id = ?")
+@Where(clause = "is_deleted = false")
 public class Portfolios extends BaseTimeEntity {
 
 	@Id
@@ -49,13 +54,29 @@ public class Portfolios extends BaseTimeEntity {
 	private Users users;
 
 	@Column(nullable = false)
-	private Boolean isDeleted;
+	private Boolean isDeleted = false;
 
 	@OneToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "file_id")
 	private Files files;
 
-	private Integer likeCount;
+	private Integer likeCount = 0;
+
+	@Builder
+	public Portfolios(String title, Users users, String portfolioTagList, String regionTag) {
+		this.title = title;
+		this.users = users;
+		this.portfolioTagList = portfolioTagList;
+		this.regionTag = regionTag;
+	}
+
+	public void setFiles(Files files) {
+		this.files = files;
+	}
+
+	public void setLikeCount(Integer likeCount) {
+		this.likeCount = likeCount;
+	}
 
 	public void updatePortfolio(String title, String regionTag, String portfolioTagList) {
 		this.title = title;
@@ -67,21 +88,4 @@ public class Portfolios extends BaseTimeEntity {
 		this.isDeleted = true;
 	}
 
-	@Builder
-	public Portfolios(String title, Users users, String portfolioTagList, String regionTag) {
-		this.title = title;
-		this.users = users;
-		this.portfolioTagList = portfolioTagList;
-		this.regionTag = regionTag;
-		this.isDeleted = false;
-		this.likeCount = 0;
-	}
-
-	public void setFiles(Files files) {
-		this.files = files;
-	}
-
-	public void setLikeCount(Integer likeCount) {
-		this.likeCount = likeCount;
-	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/repository/PortfoliosRepository.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/portfolio/repository/PortfoliosRepository.java
@@ -1,13 +1,24 @@
 package swmaestro.spaceodyssey.weddingmate.domain.portfolio.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import swmaestro.spaceodyssey.weddingmate.domain.file.entity.Files;
 import swmaestro.spaceodyssey.weddingmate.domain.portfolio.entity.Portfolios;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
 
 public interface PortfoliosRepository extends JpaRepository<Portfolios, Long> {
 
 	Optional<Portfolios> findByFiles(Files files);
+
+	List<Portfolios> findAllByUsers(Users users);
+
+	@Modifying
+	@Query("UPDATE Portfolios p SET p.isDeleted = true WHERE p.users = :user")
+	void softDeleteByUser(@Param("user") Users user);
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/entity/PlannerProfiles.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/entity/PlannerProfiles.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -25,6 +26,7 @@ public class PlannerProfiles extends BaseTimeEntity {
 	private Long plannerProfileId;
 
 	@OneToOne(mappedBy = "plannerProfiles")
+	@JoinColumn(name = "planner_id")
 	private Planners planners;
 
 	private String bio;
@@ -52,11 +54,11 @@ public class PlannerProfiles extends BaseTimeEntity {
 	}
 
 	/*================== 기존 필드값 수정 ==================*/
-	public void updateBio(String bio){
+	public void updateBio(String bio) {
 		this.bio = bio;
 	}
 
-	public void updateSns(String sns){
+	public void updateSns(String sns) {
 		this.sns = sns;
 	}
 

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/service/PlannerProfilesService.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/service/PlannerProfilesService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import swmaestro.spaceodyssey.weddingmate.domain.like.enums.LikeEnum;
-import swmaestro.spaceodyssey.weddingmate.domain.like.repository.LikesRepository;
+import swmaestro.spaceodyssey.weddingmate.domain.like.service.LikesRepositoryService;
 import swmaestro.spaceodyssey.weddingmate.domain.portfolio.dto.PortfolioListResDto;
 import swmaestro.spaceodyssey.weddingmate.domain.portfolio.mapper.PortfoliosMapper;
 import swmaestro.spaceodyssey.weddingmate.domain.profile.dto.PlannerProfileResDto;
@@ -16,44 +16,44 @@ import swmaestro.spaceodyssey.weddingmate.domain.profile.mapper.ProfilesMapper;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Planners;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
 import swmaestro.spaceodyssey.weddingmate.domain.users.mapper.PlannersMapper;
-import swmaestro.spaceodyssey.weddingmate.domain.users.service.PlannersService;
-import swmaestro.spaceodyssey.weddingmate.domain.users.service.UsersService;
+import swmaestro.spaceodyssey.weddingmate.domain.users.service.repositoryservice.PlannersRepositoryService;
+import swmaestro.spaceodyssey.weddingmate.domain.users.service.repositoryservice.UsersRepositoryService;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class PlannerProfilesService {
 
-	private final UsersService usersService;
-	private final PlannersService plannerService;
-	private final ProfilesService profilesService;
+	private final UsersRepositoryService usersRepositoryService;
+	private final PlannersRepositoryService plannersRepositoryService;
+	private final LikesRepositoryService likesRepositoryService;
+	private final ProfileRepositoryService profileRepositoryService;
 
 	private final PlannersMapper plannerMapper;
 	private final ProfilesMapper profileMapper;
 	private final PortfoliosMapper portfoliosMapper;
 
-	private final LikesRepository likeRepository;
-
-
 	public List<PlannerProfileResDto> getPlannerProfileList(Users cUsers) {
-		List<Users> plannerUserList = usersService.findAllPlannerUser();
+		List<Users> plannerUserList = usersRepositoryService.findAllPlannerUser();
 
 		return plannerUserList.parallelStream()
 			.map(user -> {
-				Planners planners = plannerService.findPlannerByUser(user);
-				Boolean isPlannerLiked = isLiked(cUsers, LikeEnum.PLANNER, planners.getPlannerId());
+				Planners planners = plannersRepositoryService.findPlannerByUsers(user);
+				Boolean isPlannerLiked = likesRepositoryService.isLiked(cUsers, LikeEnum.PLANNER,
+					planners.getPlannerId());
 				PlannerProfiles plannerProfiles = planners.getPlannerProfiles();
 				return profileMapper.toPlannerProfileResDto(user, planners, plannerProfiles, isPlannerLiked);
 			})
 			.toList();
 	}
 
-	public PlannerProfileResDto getPlannerProfileByProfileId(Users cUsers, Long userId) {
-		Users users = usersService.findUserById(userId);
-		Planners planners = plannerService.findPlannerByUser(users);
-		PlannerProfiles plannerProfiles = profilesService.findPlannerProfileByPlanner(planners);
+	public PlannerProfileResDto getPlannerProfileByUserId(Users cUsers, Long userId) {
+		Users users = usersRepositoryService.findUserById(userId);
+		Planners planners = plannersRepositoryService.findPlannerByUsers(users);
+		PlannerProfiles plannerProfiles = profileRepositoryService.findPlannerProfileById(
+			planners.getPlannerProfiles().getPlannerProfileId());
 
-		Boolean isPlannerLiked = isLiked(cUsers, LikeEnum.PLANNER, planners.getPlannerId());
+		Boolean isPlannerLiked = likesRepositoryService.isLiked(cUsers, LikeEnum.PLANNER, planners.getPlannerId());
 
 		return PlannerProfileResDto.builder()
 			.plannerProfileId(plannerProfiles.getPlannerProfileId())
@@ -66,18 +66,12 @@ public class PlannerProfilesService {
 	}
 
 	public List<PortfolioListResDto> getPlannerPortfolioByProfileId(Users cUsers, Long userId) {
-		Users users = usersService.findUserById(userId);
+		Users users = usersRepositoryService.findUserById(userId);
 
 		return users.getPortfoliosList().stream()
 			//삭제된 portfolio 제외
 			.filter(portfolio -> (Boolean.FALSE.equals(portfolio.getIsDeleted())))
 			.map(portfolio -> portfoliosMapper.entityToDto(cUsers, portfolio))
 			.toList();
-	}
-
-
-	/*================== Repository 접근 ==================*/
-	public Boolean isLiked(Users cUsers, LikeEnum likeType, Long likeId) {
-		return !likeRepository.findByUsersAndLikeTypeAndLikedId(cUsers, likeType, likeId).isEmpty();
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/service/ProfilesService.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/profile/service/ProfilesService.java
@@ -11,16 +11,14 @@ import swmaestro.spaceodyssey.weddingmate.domain.profile.dto.PlannerProfileUpdat
 import swmaestro.spaceodyssey.weddingmate.domain.profile.dto.PlannerProfileUpdateResDto;
 import swmaestro.spaceodyssey.weddingmate.domain.profile.entity.PlannerProfiles;
 import swmaestro.spaceodyssey.weddingmate.domain.profile.mapper.ProfilesMapper;
-import swmaestro.spaceodyssey.weddingmate.domain.profile.repository.PlannerProfilesRepository;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Customers;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Planners;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
 import swmaestro.spaceodyssey.weddingmate.domain.users.mapper.CustomersMapper;
 import swmaestro.spaceodyssey.weddingmate.domain.users.mapper.PlannersMapper;
 import swmaestro.spaceodyssey.weddingmate.domain.users.repository.UsersRepository;
-import swmaestro.spaceodyssey.weddingmate.domain.users.service.CustomersService;
-import swmaestro.spaceodyssey.weddingmate.domain.users.service.PlannersService;
-import swmaestro.spaceodyssey.weddingmate.global.exception.profile.PlannerProfileNotFoundException;
+import swmaestro.spaceodyssey.weddingmate.domain.users.service.repositoryservice.CustomersRepositoryService;
+import swmaestro.spaceodyssey.weddingmate.domain.users.service.repositoryservice.PlannersRepositoryService;
 import swmaestro.spaceodyssey.weddingmate.global.exception.profile.ProfileModificationNotAllowedException;
 
 @Service
@@ -28,18 +26,16 @@ import swmaestro.spaceodyssey.weddingmate.global.exception.profile.ProfileModifi
 @Transactional
 public class ProfilesService {
 
-	private final PlannerProfilesRepository plannerProfilesRepository;
-
 	private final PlannersMapper plannerMapper;
 	private final ProfilesMapper profileMapper;
 	private final CustomersMapper customersMapper;
 
-	private final PlannersService plannerService;
-	private final CustomersService customersService;
+	private final PlannersRepositoryService plannersRepositoryService;
+	private final CustomersRepositoryService customersRepositoryService;
 	private final UsersRepository usersRepository;
 
 	public PlannerProfileResDto getPlannerProfile(Users users) {
-		Planners planners = plannerService.findPlannerByUser(users);
+		Planners planners = plannersRepositoryService.findPlannerByUsers(users);
 		PlannerProfiles plannerProfiles = planners.getPlannerProfiles(); // EAGER로 인해 즉시 로딩 가능
 
 		return PlannerProfileResDto.builder()
@@ -53,7 +49,7 @@ public class ProfilesService {
 
 	@Transactional
 	public PlannerProfileUpdateResDto updatePlannerProfile(Users users, PlannerProfileUpdateReqDto reqDto) {
-		Planners planners = plannerService.findPlannerByUser(users);
+		Planners planners = plannersRepositoryService.findPlannerByUsers(users);
 		PlannerProfiles plannerProfiles = planners.getPlannerProfiles(); // EAGER로 인해 즉시 로딩 가능
 
 		// 변경사항 수정
@@ -68,7 +64,7 @@ public class ProfilesService {
 
 	@Transactional
 	public CustomerProfileResDto getCustomerProfile(Users users) {
-		Customers customers = customersService.findCustomerByUser(users);
+		Customers customers = customersRepositoryService.findCustomerByUser(users);
 
 		return CustomerProfileResDto.builder()
 			.userId(users.getUserId())
@@ -82,7 +78,7 @@ public class ProfilesService {
 
 	@Transactional
 	public void updateCustomerProfile(Users users, CustomerProfileUpdateReqDto reqDto) {
-		Customers customers = customersService.findCustomerByUser(users);
+		Customers customers = customersRepositoryService.findCustomerByUser(users);
 
 		// 변경사항 수정
 		users.updateNickname(reqDto.getNickname());
@@ -92,22 +88,9 @@ public class ProfilesService {
 		customers.updateCustomerTagList(reqDto.getCustomerTagList());
 	}
 
-	/*================== Repository 접근 ==================*/
-	@Transactional
-	public PlannerProfiles findPlannerProfileById(Long plannerProfileId) {
-		return plannerProfilesRepository.findById(plannerProfileId)
-			.orElseThrow(PlannerProfileNotFoundException::new);
-	}
-
-	@Transactional
-	public PlannerProfiles findPlannerProfileByPlanner(Planners planners) {
-		return plannerProfilesRepository.findPlannerProfilesByPlanners(planners)
-			.orElseThrow(PlannerProfileNotFoundException::new);
-	}
-
 	/*================== 검증 =================*/
 	public void checkIsProfileOwner(Users users, Long plannerProfileId) {
-		Planners planners = plannerService.findPlannerByPlannerProfileId(plannerProfileId);
+		Planners planners = plannersRepositoryService.findPlannerByPlannerProfileId(plannerProfileId);
 
 		if (!planners.getUsers().equals(users)) {
 			throw new ProfileModificationNotAllowedException();

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/controller/AuthController.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/controller/AuthController.java
@@ -1,16 +1,24 @@
 package swmaestro.spaceodyssey.weddingmate.domain.users.controller;
 
 import static org.springframework.http.HttpHeaders.*;
+import static swmaestro.spaceodyssey.weddingmate.global.constant.ResponseConstant.*;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import swmaestro.spaceodyssey.weddingmate.domain.users.dto.AccessTokenDto;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.AuthUsers;
+import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
 import swmaestro.spaceodyssey.weddingmate.domain.users.service.AuthService;
 import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponse;
 import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponseStatus;
@@ -35,18 +43,28 @@ public class AuthController {
 			.build();
 	}
 
-	@PostMapping("/blacklist")
+	@PostMapping("/logout")
 	@ResponseStatus(HttpStatus.OK)
-	public ResponseEntity<ApiResponse<Object>> signOut(@RequestBody AccessTokenDto requestDto) {
-		AccessTokenDto resDto = authService.signOut(requestDto);
+	public ResponseEntity<ApiResponse<Object>> logout(@RequestBody AccessTokenDto requestDto) {
+		authService.logout(requestDto);
 		ResponseCookie responseCookie = removeRefreshTokenCookie();
 
 		return ResponseEntity.ok()
 			.header(SET_COOKIE, responseCookie.toString())
 			.body(ApiResponse.builder()
 				.status(ApiResponseStatus.SUCCESS)
-				.data(resDto)
+				.data(LOGOUT_SUCCESS)
 				.build());
+	}
+
+	@DeleteMapping("/signout")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<Object> signout(@AuthUsers Users users, @RequestBody AccessTokenDto requestDto) {
+		authService.signout(users, requestDto);
+		return ApiResponse.builder()
+			.status(ApiResponseStatus.SUCCESS)
+			.data(SIGNOUT_SUCCESS)
+			.build();
 	}
 
 	public ResponseCookie removeRefreshTokenCookie() {

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/controller/SignupController.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/controller/SignupController.java
@@ -15,6 +15,7 @@ import swmaestro.spaceodyssey.weddingmate.domain.users.dto.CustomerSignupReqDto;
 import swmaestro.spaceodyssey.weddingmate.domain.users.dto.PlannerSignupReqDto;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.AuthUsers;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
+import swmaestro.spaceodyssey.weddingmate.domain.users.enums.UserAccountStatusEnum;
 import swmaestro.spaceodyssey.weddingmate.domain.users.enums.UserRegisterStatusEnum;
 import swmaestro.spaceodyssey.weddingmate.domain.users.service.CustomersService;
 import swmaestro.spaceodyssey.weddingmate.domain.users.service.PlannersService;
@@ -54,10 +55,27 @@ public class SignupController {
 	@GetMapping()
 	@ResponseStatus(value = HttpStatus.OK)
 	public ApiResponse<Object> checkUserRegisterStatus(@AuthUsers Users users) {
-		UserRegisterStatusEnum userRegisterStatusEnum = usersService.getUserRegisterStatus(users);
+		Object responseData;
+
+		UserAccountStatusEnum usersAccountStatus = usersService.checkUsersAccountStatus(users);
+		if (usersAccountStatus == UserAccountStatusEnum.NORMAL) {
+			responseData = usersService.getUserRegisterStatus(users);
+		} else {
+			responseData = getAccountStatusMessage(usersAccountStatus);
+		}
+
 		return ApiResponse.builder()
 			.status(ApiResponseStatus.SUCCESS)
-			.data(userRegisterStatusEnum)
+			.data(responseData)
 			.build();
+	}
+
+	private String getAccountStatusMessage(UserAccountStatusEnum accountStatus) {
+		return switch (accountStatus) {
+			case WITHDRAW -> ACCOUNT_WITHDRAW_MESSAGE;
+			case SUSPENDED -> ACCOUNT_SUSPENDED_MESSAGE;
+			case BANNED -> ACCOUNT_BANNED_MESSAGE;
+			default -> "";
+		};
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Customers.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Customers.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -30,6 +31,7 @@ public class Customers extends BaseTimeEntity {
 	private Long customerId;
 
 	@OneToOne(mappedBy = "customers")
+	@JoinColumn(name = "user_id")
 	private Users users;
 
 	@NotNull(message = "예식일 확정 여부는 필수로 입력되어야 합니다.")
@@ -54,9 +56,7 @@ public class Customers extends BaseTimeEntity {
 
 	private String makeupTagList;
 
-	@Column(nullable = false)
-	private Boolean isDeleted;
-
+	private Boolean isDeleted = false;
 
 	@Builder
 	public Customers(Boolean weddingDateConfirmed, String regionList, String budget, CustomerTagListDto customerTagList) {

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Planners.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Planners.java
@@ -2,7 +2,11 @@ package swmaestro.spaceodyssey.weddingmate.domain.users.entity;
 
 import java.util.function.Consumer;
 
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -22,6 +26,8 @@ import swmaestro.spaceodyssey.weddingmate.global.entity.BaseTimeEntity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
+@SQLDelete(sql = "UPDATE planners SET is_deleted = true WHERE planner_id = ?")
+@Where(clause = "is_deleted = false")
 public class Planners extends BaseTimeEntity {
 
 	@Id
@@ -29,6 +35,7 @@ public class Planners extends BaseTimeEntity {
 	private Long plannerId;
 
 	@OneToOne(mappedBy = "planners")
+	@JoinColumn(name = "user_id")
 	private Users users;
 
 	@NotNull(message = "소속은 필수로 입력되어야 합니다.")
@@ -46,7 +53,10 @@ public class Planners extends BaseTimeEntity {
 
 	private String plannerTagList; // 최대 3개
 
-	private Integer likeCount;
+	private Integer likeCount = 0;
+
+	@Column(nullable = false)
+	private Boolean isDeleted = false;
 
 	@Builder
 	public Planners(String company, String position, String regionList, String plannerTagList) {
@@ -54,7 +64,6 @@ public class Planners extends BaseTimeEntity {
 		this.position = position;
 		this.regionList = regionList;
 		this.plannerTagList = plannerTagList;
-		this.likeCount = 0;
 	}
 
 	public void updatePlannerInfo(PlannerInfoDto dto) {
@@ -80,15 +89,15 @@ public class Planners extends BaseTimeEntity {
 		this.company = company;
 	}
 
-	public void updatePosition(String position){
+	public void updatePosition(String position) {
 		this.position = position;
 	}
 
-	public void updateRegionList(String regionList){
+	public void updateRegionList(String regionList) {
 		this.regionList = regionList;
 	}
 
-	public void updatePlannerTagList(String plannerTagList){
+	public void updatePlannerTagList(String plannerTagList) {
 		this.plannerTagList = plannerTagList;
 	}
 
@@ -100,5 +109,9 @@ public class Planners extends BaseTimeEntity {
 
 	public void setLikeCount(Integer likeCount) {
 		this.likeCount = likeCount;
+	}
+
+	public void deletePlanners() {
+		this.isDeleted = true;
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Users.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Users.java
@@ -2,6 +2,9 @@ package swmaestro.spaceodyssey.weddingmate.domain.users.entity;
 
 import java.util.List;
 
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -31,6 +34,8 @@ import swmaestro.spaceodyssey.weddingmate.global.entity.BaseTimeEntity;
 @SuppressWarnings("checkstyle:RegexpMultiline")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@SQLDelete(sql = "UPDATE users SET account_status = 'WITHDRAW' WHERE user_id = ?")
+@Where(clause = "account_status = 'NORMAL'")
 @Entity
 public class Users extends BaseTimeEntity {
 	@Id
@@ -108,6 +113,10 @@ public class Users extends BaseTimeEntity {
 
 	public void updateRegisterStatus(UserRegisterStatusEnum registerStatus) {
 		this.registerStatus = registerStatus;
+	}
+
+	public void updateAccountStatus(UserAccountStatusEnum accountStatus) {
+		this.accountStatus = accountStatus;
 	}
 
 	public void updateNickname(String nickname) {

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/repository/CustomersRepository.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/repository/CustomersRepository.java
@@ -3,10 +3,19 @@ package swmaestro.spaceodyssey.weddingmate.domain.users.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Customers;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
 
 public interface CustomersRepository extends JpaRepository<Customers, Long> {
 	Optional<Customers> findByUsers(Users users);
+
+	@Modifying
+	@Transactional
+	@Query("UPDATE Customers c SET c.isDeleted = true WHERE c.customerId = :customerId")
+	void softDeleteCustomerByCustomerId(@Param("customerId") Long customerId);
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/repository/PlannersRepository.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/repository/PlannersRepository.java
@@ -3,6 +3,10 @@ package swmaestro.spaceodyssey.weddingmate.domain.users.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Planners;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
@@ -10,4 +14,9 @@ import swmaestro.spaceodyssey.weddingmate.domain.users.entity.Users;
 public interface PlannersRepository extends JpaRepository<Planners, Long> {
 	Optional<Planners> findByUsers(Users users);
 	Optional<Planners> findByPlannerProfiles_PlannerProfileId(Long plannerProfileId);
+
+	@Modifying
+	@Transactional
+	@Query("UPDATE Planners p SET p.isDeleted = true WHERE p.plannerId = :plannerId")
+	void softDeletePlannerByPlannerId(@Param("plannerId") Long plannerId);
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/global/config/SecurityConfig.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/global/config/SecurityConfig.java
@@ -105,6 +105,8 @@ public class SecurityConfig {
 		configuration.addAllowedOrigin("http://localhost:5173");
 		configuration.addAllowedOrigin("https://weddingmate.co.kr");
 		configuration.addAllowedOrigin("https://dev.weddingmate.co.kr");
+		configuration.addAllowedOrigin("https://server.weddingmate.co.kr");
+		configuration.addAllowedOrigin("https://api.weddingmate.co.kr");
 		configuration.setAllowCredentials(true); // 클라이언트에서 쿠키 요청 허용
 		configuration.setAllowedOriginPatterns(Collections.singletonList("*")); // 모든 IP 주소 허용 (프론트엔드 IP, react만 허용) 핸드폰은 js 요청을 하지 않고 java나 swift 쓰기 때문에 cors에 안 걸림
 		configuration.setMaxAge(MAX_AGE_SECS);

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/global/constant/ResponseConstant.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/global/constant/ResponseConstant.java
@@ -16,6 +16,15 @@ public class ResponseConstant {
 	// customer
 	public static final String CUSTOMER_SIGNUP_SUCCESS = " 고객님의 회원가입이 완료되었습니다.";
 
+	public static final String LOGOUT_SUCCESS = "로그아웃에 성공했습니다.";
+	public static final String SIGNOUT_SUCCESS = "회원 탈퇴에 성공했습니다.";
+
+	// accountStatus
+
+	public static final String ACCOUNT_SUSPENDED_MESSAGE = "정지된 계정입니다.";
+	public static final String ACCOUNT_WITHDRAW_MESSAGE = "이미 탈퇴한 계정입니다.";
+	public static final String ACCOUNT_BANNED_MESSAGE = "재가입 불가능한 계정입니다.";
+
 	// exception
 	public static final String USER_NOTFOUND = "해당 유저를 찾을 수 없습니다.";
 	public static final String USER_NAME_NOTFOUND = "해당 유저의 이름을 찾을 수 없습니다(CustomUserDetailsService)";


### PR DESCRIPTION
### 작업 개요
회원 탈퇴 시 user, customer, planner, portfolio, item, like가 soft delete 되도록 설정

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->

### 작업 상세 내용
회원 탈퇴 시 user의 상태가 WITHDRAW로 변경되고, 연결된 객체들의 is_deleted 컬럼이 true로 변경됩니다

각 entity에는 아래처럼 조건을 걸어놓아, 삭제된 객체는 조회가 되지 않도록 설정했습니다.
entity 단에서 로직을 설정해놓았기 때문에  service로직에서 checkIsDeleted 관련 함수를 삭제했습니다.
```java
@SQLDelete(sql = "UPDATE portfolios SET is_deleted = true WHERE portfolio_id = ?")
@Where(clause = "is_deleted = false")
```

### 한꺼번에 논리적으로 삭제
Item의 경우 지연 로딩으로 구성되어 있기 때문에 item.portfolio.user = :user 로직이 작동하지 않았습니다.
따라서 join을 사용해 item을 불러오고, 그 후에 userId와 일치하는지 체크하였습니다

사용자와 연관된 모든 아이템을 한꺼번에 논리적으로 삭제하기 때문에 쿼리가 적게 나간다는 장점이 있습니다

(fetch join을 쓰고 싶었는데 데이터 조회에만 적용할 수 있대서 그냥 일반 join으로 했습니다)

### 생각해볼 문제
- 예를 들어 item을 클릭했는데 작성자가 이미 탈퇴한 회원이거나, 포트폴리오가 이미 삭제된 경우 프론트에게 어떤 식으로 전달해야 할 지 생각해보아야 합니다.