### PR TITLE
[SO-269] feat : CodeDeploy를 활용한 CD 파이프라인 분리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
   # 특정 브랜치로 푸시될 때에만 워크플로우를 실행합니다.
   push:
     branches:
-      - feature/SO-269-codedeploy-pipeline
+      - develop
 jobs:
   build:
     name: Build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
   # 특정 브랜치로 푸시될 때에만 워크플로우를 실행합니다.
   push:
     branches:
-      - develop
+      - feature/SO-269-codedeploy-pipeline
 jobs:
   build:
     name: Build
@@ -36,24 +36,6 @@ jobs:
           touch .env
           echo "${{ secrets.ENV_VARS }}" >> .env
 
-      - name: Create remote directory
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.HOST }}
-          username: ubuntu
-          key: ${{ secrets.KEY }}
-          port: 22
-          script: mkdir -p /home/ubuntu/srv/weddingmate
-
-      - name: Copy source via SSH key
-        uses: burnett01/rsync-deployments@4.1
-        with:
-          switches: -avzr --delete
-          remote_path: /home/ubuntu/srv/weddingmate
-          remote_host: ${{ secrets.HOST }}
-          remote_user: ubuntu
-          remote_key: ${{ secrets.KEY }}
-
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
@@ -67,38 +49,27 @@ jobs:
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          
-        # mkdir scripts
-        # touch scripts/deploy.sh
-        # echo "aws ecr get-login-password --region ap-northeast-2 | sudo docker login --username AWS --password-stdin $ECR_REGISTRY" >> scripts/deploy.sh
-        # echo "sudo docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> scripts/deploy.sh
-        # echo "sh /home/ubuntu/srv/weddingmate/config/scripts/deploy.sh" >> scripts/deploy.sh
+          mkdir scripts
+          touch scripts/deploy.sh
+          echo "aws ecr get-login-password --region ap-northeast-2 | sudo docker login --username AWS --password-stdin $ECR_REGISTRY" >> scripts/deploy.sh
+          echo "sudo docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> scripts/deploy.sh
+          echo "sh /home/ubuntu/srv/weddingmate/config/scripts/deploy.sh $IMAGE_TAG" >> scripts/deploy.sh
 
-      # - name: Upload to S3
-      #   env:
-      #     ZIP_TAG: ${{ github.sha }}
-      #   run: |
-      #     zip -r deploy-$ZIP_TAG.zip ./scripts appspec.yml
-      #     aws s3 cp --region ap-northeast-2 --acl private ./deploy-$ZIP_TAG.zip s3://weddingmate-codedeploy-bucket
+      - name: Upload to S3
+        env:
+          ZIP_TAG: ${{ github.sha }}
+        run: |
+          zip -r deploy-$ZIP_TAG.zip ./scripts appspec.yml
+          aws s3 cp --region ap-northeast-2 --acl private ./deploy-$ZIP_TAG.zip s3://weddingmate-codedeploy-bucket
        
-      # - name: Start deploy
-      #   env:
-      #     IMAGE_TAG: ${{ github.sha }}
-      #   run: |
-      #     aws deploy create-deployment --application-name deploy \
-      #     --deployment-config-name CodeDeployDefault.OneAtATime \
-      #     --deployment-group-name deploy-group \
-      #     --s3-location bucket=weddingmate-codedeploy-bucket,bundleType=zip,key=deploy-$IMAGE_TAG.zip
-            
-      - name: Delete unused images and containers
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.HOST }}
-          username: ubuntu
-          key: ${{ secrets.KEY }}
-          IMAGE_TAG: latest
-          script: |
-            sh /home/ubuntu/srv/weddingmate/config/scripts/deploy.sh $IMAGE_TAG
+      - name: Start deploy
+        env:
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          aws deploy create-deployment --application-name deploy \
+          --deployment-config-name CodeDeployDefault.OneAtATime \
+          --deployment-group-name deploy-group \
+          --s3-location bucket=weddingmate-codedeploy-bucket,bundleType=zip,key=deploy-$IMAGE_TAG.zip
       
       - name: Slack notification
         uses: 8398a7/action-slack@v3
@@ -109,12 +80,3 @@ jobs:
         env:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: always()
-        
-      - name: Delete unused images and containers
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.HOST }}
-          username: ubuntu
-          key: ${{ secrets.KEY }}
-          script: |
-            sh /home/ubuntu/srv/weddingmate/config/scripts/delete.sh


### PR DESCRIPTION
### 작업 개요
- code deploy를 활용한 CD 파이프라인 구성
- github actions에서는 CI 역할만 하도록 분리
<!--
  ex) 고양이가 야옹 소리를 내도록 수정
-->

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->

### 작업 상세 내용
1. code deploy를 활용한 무중단 배포 환경 설계
2. blue green 배포 전략을 선택하기 위한 ec2 auto scaling 구성
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  3. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->

### 생각해볼 문제
- 현재 이미지의 태그를 latest로 축약하여 표시중인데 그 이유는 이미지 별 고유 태그를 docker-compose.yml 에 주입하는 방법을 알아내는데 실패했기 때문이다. 하지만 이는 좋지 않은 이미지 태깅 방식이기 때문에 추후 개선해야 할 사항으로 보인다.
<!--
  ex) 
  1. wav 파일을 매번 입력하기 귀찮겠다.
-->

### 링크
- WeddingMate Backend Wiki에 자세한 구축 과정을 설명해두었으니 참조 바랍니다.
[CI/CD 파이프라인 구축](https://github.com/SWM-Space-Odyssey/WeddingMate_BackEnd/wiki/CI-CD-%ED%8C%8C%EC%9D%B4%ED%94%84%EB%9D%BC%EC%9D%B8-%EA%B5%AC%EC%B6%95-:-Github-Actions,-CodeDeploy%E2%80%90Blue-Green-%EB%B0%B0%ED%8F%AC-%EC%A0%84%EB%9E%B5,-Auto-Scaling%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%98%EC%97%AC)