### PR TITLE
[SO-288] fix: codedeploy 스크립트 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,6 @@ jobs:
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          mkdir config/codedeploy
           
           touch config/codedeploy/deploy.sh
           echo "aws ecr get-login-password --region ap-northeast-2 | sudo docker login --username AWS --password-stdin $ECR_REGISTRY" >> config/codedeploy/deploy.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
   # 특정 브랜치로 푸시될 때에만 워크플로우를 실행합니다.
   push:
     branches:
-      - features/SO-288-fix-codedeploy-script
+      - develop
 jobs:
   build:
     name: Build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,17 +49,18 @@ jobs:
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          mkdir scripts
-          touch scripts/deploy.sh
-          echo "aws ecr get-login-password --region ap-northeast-2 | sudo docker login --username AWS --password-stdin $ECR_REGISTRY" >> scripts/deploy.sh
-          echo "sudo docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> scripts/deploy.sh
-          echo "sh /home/ubuntu/srv/weddingmate/config/scripts/deploy.sh $IMAGE_TAG" >> scripts/deploy.sh
+          mkdir config/codedeploy
+          
+          touch config/codedeploy/deploy.sh
+          echo "aws ecr get-login-password --region ap-northeast-2 | sudo docker login --username AWS --password-stdin $ECR_REGISTRY" >> config/codedeploy/deploy.sh
+          echo "sudo docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> config/codedeploy/deploy.sh
+          echo "sh /home/ubuntu/srv/weddingmate/config/codedeploy/deploy.sh $IMAGE_TAG" >> config/codedeploy/deploy.sh
 
       - name: Upload to S3
         env:
           ZIP_TAG: ${{ github.sha }}
         run: |
-          zip -r deploy-$ZIP_TAG.zip ./scripts appspec.yml
+          zip -r deploy-$ZIP_TAG.zip ./config/codedeploy appspec.yml
           aws s3 cp --region ap-northeast-2 --acl private ./deploy-$ZIP_TAG.zip s3://weddingmate-codedeploy-bucket
        
       - name: Start deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
   # 특정 브랜치로 푸시될 때에만 워크플로우를 실행합니다.
   push:
     branches:
-      - develop
+      - features/SO-288-fix-codedeploy-script
 jobs:
   build:
     name: Build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,6 @@ jobs:
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          mkdir config
           mkdir config/codedeploy
           
           touch config/codedeploy/deploy.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          mkdir config/codedeploy
+          cd config/codedeploy
           
           touch config/codedeploy/deploy.sh
           echo "aws ecr get-login-password --region ap-northeast-2 | sudo docker login --username AWS --password-stdin $ECR_REGISTRY" >> config/codedeploy/deploy.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
           touch config/codedeploy/deploy.sh
           echo "aws ecr get-login-password --region ap-northeast-2 | sudo docker login --username AWS --password-stdin $ECR_REGISTRY" >> config/codedeploy/deploy.sh
           echo "sudo docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> config/codedeploy/deploy.sh
-          echo "sh /home/ubuntu/srv/weddingmate/config/codedeploy/deploy.sh $IMAGE_TAG" >> config/codedeploy/deploy.sh
+          echo "sh /home/ubuntu/srv/weddingmate/config/scripts/deploy.sh $IMAGE_TAG" >> config/codedeploy/deploy.sh
 
       - name: Upload to S3
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           cd config/codedeploy
           
-          cat > config/codedeploy/deploy.sh
+          touch deploy.sh
           echo "aws ecr get-login-password --region ap-northeast-2 | sudo docker login --username AWS --password-stdin $ECR_REGISTRY" >> config/codedeploy/deploy.sh
           echo "sudo docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> config/codedeploy/deploy.sh
           echo "sh /home/ubuntu/srv/weddingmate/config/codedeploy/deploy.sh $IMAGE_TAG" >> config/codedeploy/deploy.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          cd config/codedeploy
+          cd config/codedeploy/
           
           touch deploy.sh
           echo "aws ecr get-login-password --region ap-northeast-2 | sudo docker login --username AWS --password-stdin $ECR_REGISTRY" >> config/codedeploy/deploy.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,9 +49,10 @@ jobs:
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          cd config/codedeploy/
+          mkdir config
+          mkdir config/codedeploy
           
-          touch deploy.sh
+          touch config/codedeploy/deploy.sh
           echo "aws ecr get-login-password --region ap-northeast-2 | sudo docker login --username AWS --password-stdin $ECR_REGISTRY" >> config/codedeploy/deploy.sh
           echo "sudo docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> config/codedeploy/deploy.sh
           echo "sh /home/ubuntu/srv/weddingmate/config/codedeploy/deploy.sh $IMAGE_TAG" >> config/codedeploy/deploy.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           cd config/codedeploy
           
-          touch config/codedeploy/deploy.sh
+          cat > config/codedeploy/deploy.sh
           echo "aws ecr get-login-password --region ap-northeast-2 | sudo docker login --username AWS --password-stdin $ECR_REGISTRY" >> config/codedeploy/deploy.sh
           echo "sudo docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> config/codedeploy/deploy.sh
           echo "sh /home/ubuntu/srv/weddingmate/config/codedeploy/deploy.sh $IMAGE_TAG" >> config/codedeploy/deploy.sh

--- a/appspec.yml
+++ b/appspec.yml
@@ -13,6 +13,9 @@ permissions:
       mode: 755
 
 hooks:
+    BeforeInstall:
+        - location: config/codedeploy/beforeInstall.sh
+          timeout: 100
     AfterInstall:
         - location: scripts/deploy.sh
           timeout: 60

--- a/appspec.yml
+++ b/appspec.yml
@@ -17,6 +17,6 @@ hooks:
         - location: config/codedeploy/beforeInstall.sh
           timeout: 100
     AfterInstall:
-        - location: scripts/deploy.sh
+        - location: config/codedeploy/deploy.sh
           timeout: 60
           runas: ubuntu

--- a/config/codedeploy/beforeInstall.sh
+++ b/config/codedeploy/beforeInstall.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ -d /home/ubuntu/srv/weddingmate/ ]; then
-  rm -rf /home/ubuntu/srv/weddingmate/
+if [ -d /home/ubuntu/srv/weddingmate/src/ ]; then
+  rm -rf /home/ubuntu/srv/weddingmate/src/
 fi
-mkdir -vp /home/ubuntu/srv/weddingmate/
+mkdir -vp /home/ubuntu/srv/weddingmate/src/

--- a/config/codedeploy/beforeInstall.sh
+++ b/config/codedeploy/beforeInstall.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if [ -d /home/ubuntu/srv/weddingmate/ ]; then
+  rm -rf /home/ubuntu/srv/weddingmate/
+fi
+mkdir -vp /home/ubuntu/srv/weddingmate/


### PR DESCRIPTION
### 작업 개요
DeploymentLimitExceededException(**The deployment failed because a specified file already exists at this location: ~**)을 해결하기 위해 beforeInstall.sh 추가

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->

### 작업 상세 내용
#### 문제 상황
- codeDeploy에서 문제가 생겨 배포가 3단계까지 진행되지 않아(무한 로딩), 변경 사항이 배포 서버에 반영되지 않는 상태
- 이로 인해 swagger, actuator에서 401 오류 발생

`DeploymentLimitExceededException` 문제가 발생하여 github action이 실행되지 않음
따라서 지금까지는 수동으로 codeDeploy에 이미 돌아가고 있는 이미지를 중지하고 매번 다시 실행시켜야 했음

#### 해결 방안
- 이미 파일이 존재할 경우 삭제 후 진행할 수도 있고, overwrite도 가능했는데 1번 방법이 정석이라 그것으로 진행
- appspec.yml의 hook에 beforeInstall 추가 

### 생각해볼 문제
<!--
  ex) 
  1. wav 파일을 매번 입력하기 귀찮겠다.
-->