### PR TITLE
[SO-298] feat: 카카오 로그인 시 gender와 age 추가

### DIFF
--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/oauth2/KakaoOAuth2User.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/oauth2/KakaoOAuth2User.java
@@ -2,13 +2,16 @@ package swmaestro.spaceodyssey.weddingmate.domain.oauth2;
 
 import java.util.Map;
 
+import static swmaestro.spaceodyssey.weddingmate.global.constant.ResponseConstant.OAUTH_AGE_NOT_PROVIDED;
+import static swmaestro.spaceodyssey.weddingmate.global.constant.ResponseConstant.OAUTH_GENDER_NOT_PROVIDED;
+
 public class KakaoOAuth2User extends OAuth2UserInfo {
 
 	private Long oauth2Id;
 
 	public KakaoOAuth2User(Map<String, Object> attributes) {
-		super((Map<String, Object>)attributes.get("kakao_account"));
-		this.oauth2Id = (Long)attributes.get("id");
+		super((Map<String, Object>) attributes.get("kakao_account"));
+		this.oauth2Id = (Long) attributes.get("id");
 	}
 
 	@Override
@@ -18,16 +21,34 @@ public class KakaoOAuth2User extends OAuth2UserInfo {
 
 	@Override
 	public String getName() {
-		return (String)((Map<String, Object>)attributes.get("profile")).get("nickname");
+		return (String) ((Map<String, Object>) attributes.get("profile")).get("nickname");
 	}
 
 	@Override
 	public String getEmail() {
-		return (String)attributes.get("email");
+		return (String) attributes.get("email");
 	}
 
 	@Override
 	public String getImageUrl() {
-		return (String)((Map<String, Object>)attributes.get("profile")).get("thumbnail_image_url");
+		return (String) ((Map<String, Object>) attributes.get("profile")).get("thumbnail_image_url");
+	}
+
+	@Override
+	public String getGender() {
+		String gender = (String) attributes.get("gender");
+		if (gender == null) {
+			gender = OAUTH_GENDER_NOT_PROVIDED;
+		}
+		return gender;
+	}
+
+	@Override
+	public String getAge() {
+		String age = (String) attributes.get("age_range");
+		if (age == null) {
+			age = OAUTH_AGE_NOT_PROVIDED;
+		}
+		return age;
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/oauth2/OAuth2UserInfo.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/oauth2/OAuth2UserInfo.java
@@ -1,9 +1,9 @@
 package swmaestro.spaceodyssey.weddingmate.domain.oauth2;
 
-import java.util.Map;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.util.Map;
 
 @Getter
 @AllArgsConstructor
@@ -22,4 +22,8 @@ public abstract class OAuth2UserInfo {
 	public abstract String getEmail();
 
 	public abstract String getImageUrl();
+
+	public abstract String getGender();
+
+	public abstract String getAge();
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,29 +1,29 @@
 package swmaestro.spaceodyssey.weddingmate.domain.oauth2.handler;
 
-import static swmaestro.spaceodyssey.weddingmate.domain.oauth2.service.CookieAuthorizationRequestRepository.*;
-
-import java.io.IOException;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseCookie;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
-import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
-
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 import swmaestro.spaceodyssey.weddingmate.domain.oauth2.UserPrincipal;
 import swmaestro.spaceodyssey.weddingmate.domain.oauth2.service.CookieAuthorizationRequestRepository;
+import swmaestro.spaceodyssey.weddingmate.domain.users.enums.UserAccountStatusEnum;
 import swmaestro.spaceodyssey.weddingmate.global.config.jwt.JwtTokenProvider;
 import swmaestro.spaceodyssey.weddingmate.global.config.redis.RedisService;
 import swmaestro.spaceodyssey.weddingmate.global.utils.CookieUtils;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static swmaestro.spaceodyssey.weddingmate.domain.oauth2.service.CookieAuthorizationRequestRepository.REDIRECT_URL_PARAM_COOKIE_KEY;
 
 @Slf4j
 @Component
@@ -39,13 +39,20 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
-		Authentication authentication) throws IOException, ServletException {
+										Authentication authentication) throws IOException, ServletException {
 
-		UserPrincipal userPrincipal = (UserPrincipal)authentication.getPrincipal();
+		UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
 		String email = userPrincipal.getEmail();
+		UserAccountStatusEnum userAccountStatus = userPrincipal.getUsers().getAccountStatus();
 
 		String targetUrl = determineTargetUrl(request, response, authentication);
-		String redirectUrl = makeRedirectUrl(email, targetUrl);
+		boolean isEligible = checkIsEligible(userAccountStatus);
+		String redirectUrl;
+		if (isEligible) {
+			redirectUrl = makeRedirectUrl(email, targetUrl);
+		} else {
+			redirectUrl = makeNonEligibleRedirectUrl(targetUrl);
+		}
 
 		ResponseCookie responseCookie = generateRefreshTokenCookie(email);
 		response.setHeader("Set-Cookie", responseCookie.toString());
@@ -61,14 +68,27 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 		getRedirectStrategy().sendRedirect(request, response, redirectUrl);
 	}
 
+	@Override
 	protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response,
-		Authentication authentication) {
+										Authentication authentication) {
 		Optional<String> redirectUrl = CookieUtils.getCookie(request, REDIRECT_URL_PARAM_COOKIE_KEY)
-			.map(Cookie::getValue);
+				.map(Cookie::getValue);
 
 		String targetUrl = redirectUrl.orElse(getDefaultTargetUrl());
 		return UriComponentsBuilder.fromUriString(targetUrl)
-			.build().toUriString();
+				.build().toUriString();
+	}
+
+	private String makeNonEligibleRedirectUrl(String redirectUrl) {
+		if (redirectUrl.equals(getDefaultTargetUrl())) {
+			redirectUrl = loginRedirectUrl;
+		}
+
+		return UriComponentsBuilder.fromHttpUrl(redirectUrl)
+				.path("/oauth2/error")
+				.build()
+				.encode() // percent-endcoding
+				.toUriString();
 	}
 
 	private String makeRedirectUrl(String email, String redirectUrl) {
@@ -79,20 +99,20 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 		String accessToken = tokenProvider.createAccessToken(email);
 
 		logger.info(UriComponentsBuilder.fromHttpUrl(redirectUrl)
-			.path("/oauth2/redirect")
-			.queryParam("accessToken", accessToken)
-			.queryParam("redirectUrl", redirectUrl)
-			.build()
-			.encode() // percent-endcoding
-			.toUriString());
+				.path("/oauth2/redirect")
+				.queryParam("accessToken", accessToken)
+				.queryParam("redirectUrl", redirectUrl)
+				.build()
+				.encode() // percent-endcoding
+				.toUriString());
 
 		return UriComponentsBuilder.fromHttpUrl(redirectUrl)
-			.path("/oauth2/redirect")
-			.queryParam("accessToken", accessToken)
-			.queryParam("redirectUrl", redirectUrl)
-			.build()
-			.encode() // percent-endcoding
-			.toUriString();
+				.path("/oauth2/redirect")
+				.queryParam("accessToken", accessToken)
+				.queryParam("redirectUrl", redirectUrl)
+				.build()
+				.encode() // percent-endcoding
+				.toUriString();
 	}
 
 	protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
@@ -109,12 +129,16 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 		redisService.setData("RefreshToken:" + email, refreshToken, refreshTokenValidationTime);
 
 		return ResponseCookie.from("refreshToken", refreshToken)
-			.path("/") // 해당 경로 하위의 페이지에서만 쿠키 접근 허용. 모든 경로에서 접근 허용한다.
-			.domain(".weddingmate.co.kr")
-			.maxAge(TimeUnit.MILLISECONDS.toSeconds(refreshTokenValidationTime)) // 쿠키 만료 시기(초). 없으면 브라우저 닫힐 때 제거
-			.secure(true) // HTTPS로 통신할 때만 쿠키가 전송된다.
-			.sameSite("None") // 크로스 사이트에도 쿠키 전송 가능
-			.httpOnly(true) // JS를 통한 쿠키 접근을 막아, XSS 공격 등을 방어하기 위한 옵션이다.
-			.build();
+				.path("/") // 해당 경로 하위의 페이지에서만 쿠키 접근 허용. 모든 경로에서 접근 허용한다.
+				.domain(".weddingmate.co.kr")
+				.maxAge(TimeUnit.MILLISECONDS.toSeconds(refreshTokenValidationTime)) // 쿠키 만료 시기(초). 없으면 브라우저 닫힐 때 제거
+				.secure(true) // HTTPS로 통신할 때만 쿠키가 전송된다.
+				.sameSite("None") // 크로스 사이트에도 쿠키 전송 가능
+				.httpOnly(true) // JS를 통한 쿠키 접근을 막아, XSS 공격 등을 방어하기 위한 옵션이다.
+				.build();
+	}
+
+	public boolean checkIsEligible(UserAccountStatusEnum userAccountStatus) {
+		return !userAccountStatus.equals(UserAccountStatusEnum.NON_ELIGIBLE);
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/oauth2/service/CustomOAuth2UserService.java
@@ -1,7 +1,8 @@
 package swmaestro.spaceodyssey.weddingmate.domain.oauth2.service;
 
-import java.util.Optional;
-
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -10,9 +11,6 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
-
-import jakarta.transaction.Transactional;
-import lombok.RequiredArgsConstructor;
 import swmaestro.spaceodyssey.weddingmate.domain.file.entity.Files;
 import swmaestro.spaceodyssey.weddingmate.domain.oauth2.OAuth2UserInfo;
 import swmaestro.spaceodyssey.weddingmate.domain.oauth2.OAuth2UserInfoFactory;
@@ -24,6 +22,11 @@ import swmaestro.spaceodyssey.weddingmate.domain.users.repository.UsersRepositor
 import swmaestro.spaceodyssey.weddingmate.global.exception.oauth2.OAuth2AuthProviderIdNotFoundException;
 import swmaestro.spaceodyssey.weddingmate.global.exception.oauth2.OAuth2DuplicateEmailException;
 
+import java.util.Optional;
+
+import static swmaestro.spaceodyssey.weddingmate.global.constant.ResponseConstant.OAUTH_AGE_NOT_PROVIDED;
+import static swmaestro.spaceodyssey.weddingmate.global.constant.ResponseConstant.OAUTH_GENDER_NOT_PROVIDED;
+
 @Transactional
 @RequiredArgsConstructor
 @Service
@@ -31,6 +34,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 	private final UsersRepository usersRepository;
 	private final ProfilesFilesUploadService profilesFilesUploadService;
+
+	@Value("${LOGIN_REDIRECT_URL}")
+	private String loginRedirectUrl;
 
 	/* OAuth2UserRequest에 이는 Access Token으로 유저 정보를 가져온다 */
 	@Override
@@ -46,10 +52,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 	protected OAuth2User processOAuth2User(OAuth2UserRequest userRequest, OAuth2User oAuth2User) {
 		// 로그인 플랫폼 확인(원래는 enum으로 하지만 우리는 kakao만 함)
 		AuthProvider authProvider = AuthProvider.valueOf(
-			userRequest.getClientRegistration().getRegistrationId().toUpperCase());
+				userRequest.getClientRegistration().getRegistrationId().toUpperCase());
 
 		OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(authProvider,
-			oAuth2User.getAttributes());
+				oAuth2User.getAttributes());
 
 		if (!StringUtils.hasLength(oAuth2UserInfo.getOAuth2Id())) {
 			throw new OAuth2AuthProviderIdNotFoundException();
@@ -73,16 +79,24 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 		try {
 			Files profileImage = profilesFilesUploadService.createUserProfile(oAuth2UserInfo.getOAuth2Id(), oAuth2UserInfo.getImageUrl());
 
+			boolean isTargetUser = checkOAuth2UserGenderAndAge(oAuth2UserInfo);
+
 			Users users = Users.builder()
-				.nickname(oAuth2UserInfo.getName())
-				.email(oAuth2UserInfo.getEmail())
-				.authProvider(authProvider)
-				.profileImage(profileImage)
-				.authProviderId(oAuth2UserInfo.getOAuth2Id())
-				.build();
+					.nickname(oAuth2UserInfo.getName())
+					.email(oAuth2UserInfo.getEmail())
+					.gender(oAuth2UserInfo.getGender())
+					.age(oAuth2UserInfo.getAge())
+					.authProvider(authProvider)
+					.profileImage(profileImage)
+					.authProviderId(oAuth2UserInfo.getOAuth2Id())
+					.build();
+
+			if (!isTargetUser) {
+				users.setAccountStatusToNotEligible();
+			}
 
 			return usersRepository.save(users);
-		} catch (DataIntegrityViolationException e){
+		} catch (DataIntegrityViolationException e) {
 			// 이미 등록된 이메일 주소인 경우 DataIntegrityViolationException 발생
 			throw new OAuth2DuplicateEmailException(authProvider);
 		}
@@ -90,5 +104,12 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 	private Users updateUser(Users users, OAuth2UserInfo oAuth2UserInfo) {
 		return usersRepository.save(users.updateOAuth2Info(oAuth2UserInfo));
+	}
+
+	private boolean checkOAuth2UserGenderAndAge(OAuth2UserInfo oAuth2UserInfo) {
+		String gender = oAuth2UserInfo.getGender();
+		String age = oAuth2UserInfo.getAge();
+
+		return !gender.equals(OAUTH_GENDER_NOT_PROVIDED) && !age.equals(OAUTH_AGE_NOT_PROVIDED) && (age.equals("20~29") || age.equals("30~39"));
 	}
 }

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/controller/SignupController.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/controller/SignupController.java
@@ -1,18 +1,10 @@
 package swmaestro.spaceodyssey.weddingmate.domain.users.controller;
 
-import static swmaestro.spaceodyssey.weddingmate.global.constant.ResponseConstant.*;
-
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 import swmaestro.spaceodyssey.weddingmate.domain.users.dto.CustomerSignupReqDto;
 import swmaestro.spaceodyssey.weddingmate.domain.users.dto.PlannerSignupReqDto;
 import swmaestro.spaceodyssey.weddingmate.domain.users.entity.AuthUsers;
@@ -23,6 +15,8 @@ import swmaestro.spaceodyssey.weddingmate.domain.users.service.PlannersService;
 import swmaestro.spaceodyssey.weddingmate.domain.users.service.UsersService;
 import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponse;
 import swmaestro.spaceodyssey.weddingmate.global.dto.ApiResponseStatus;
+
+import static swmaestro.spaceodyssey.weddingmate.global.constant.ResponseConstant.*;
 
 @Tag(name = "Signup API", description = "회원가입 API")
 @RestController
@@ -40,9 +34,9 @@ public class SignupController {
 	public ApiResponse<Object> plannerSignup(@AuthUsers Users users, @RequestBody PlannerSignupReqDto reqDto) {
 		plannerService.signupPlanner(users, reqDto);
 		return ApiResponse.builder()
-			.status(ApiResponseStatus.SUCCESS)
-			.data(reqDto.getNickname() + PLANNER_SIGNUP_SUCCESS)
-			.build();
+				.status(ApiResponseStatus.SUCCESS)
+				.data(reqDto.getNickname() + PLANNER_SIGNUP_SUCCESS)
+				.build();
 	}
 
 	@Operation(summary = "예비부부 회원가입")
@@ -51,13 +45,13 @@ public class SignupController {
 	public ApiResponse<Object> customerSignup(@AuthUsers Users users, @RequestBody CustomerSignupReqDto reqDto) {
 		customersService.signupCustomer(users, reqDto);
 		return ApiResponse.builder()
-			.status(ApiResponseStatus.SUCCESS)
-			.data(reqDto.getNickname() + CUSTOMER_SIGNUP_SUCCESS)
-			.build();
+				.status(ApiResponseStatus.SUCCESS)
+				.data(reqDto.getNickname() + CUSTOMER_SIGNUP_SUCCESS)
+				.build();
 	}
 
 	@Operation(summary = "유저의 가입 상태 확인(UNREGISTERED, CUSTOMER, PLANNER")
-	@GetMapping()
+	@GetMapping("/check-registration")
 	@ResponseStatus(value = HttpStatus.OK)
 	public ApiResponse<Object> checkUserRegisterStatus(@AuthUsers Users users) {
 		Object responseData;
@@ -70,16 +64,18 @@ public class SignupController {
 		}
 
 		return ApiResponse.builder()
-			.status(ApiResponseStatus.SUCCESS)
-			.data(responseData)
-			.build();
+				.status(ApiResponseStatus.SUCCESS)
+				.data(responseData)
+				.build();
 	}
+
 
 	private String getAccountStatusMessage(UserAccountStatusEnum accountStatus) {
 		return switch (accountStatus) {
 			case WITHDRAW -> ACCOUNT_WITHDRAW_MESSAGE;
 			case SUSPENDED -> ACCOUNT_SUSPENDED_MESSAGE;
 			case BANNED -> ACCOUNT_BANNED_MESSAGE;
+			case NON_ELIGIBLE -> ACCOUNT_NON_ELIGIBLE_MESSAGE;
 			default -> "";
 		};
 	}

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Users.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/entity/Users.java
@@ -1,28 +1,14 @@
 package swmaestro.spaceodyssey.weddingmate.domain.users.entity;
 
-import java.util.List;
-
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import swmaestro.spaceodyssey.weddingmate.domain.file.entity.Files;
 import swmaestro.spaceodyssey.weddingmate.domain.oauth2.OAuth2UserInfo;
 import swmaestro.spaceodyssey.weddingmate.domain.oauth2.enums.AuthProvider;
@@ -30,6 +16,8 @@ import swmaestro.spaceodyssey.weddingmate.domain.portfolio.entity.Portfolios;
 import swmaestro.spaceodyssey.weddingmate.domain.users.enums.UserAccountStatusEnum;
 import swmaestro.spaceodyssey.weddingmate.domain.users.enums.UserRegisterStatusEnum;
 import swmaestro.spaceodyssey.weddingmate.global.entity.BaseTimeEntity;
+
+import java.util.List;
 
 @SuppressWarnings("checkstyle:RegexpMultiline")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -43,11 +31,18 @@ public class Users extends BaseTimeEntity {
 	private Long userId;
 
 	@Email(message = "올바르지 않은 이메일 형식입니다.",
-		regexp = "^[\\w!#$%&'*+/=?`{|}~^-]+(?:\\.[\\w!#$%&'*+/=?`{|}~^-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}$")
+			regexp = "^[\\w!#$%&'*+/=?`{|}~^-]+(?:\\.[\\w!#$%&'*+/=?`{|}~^-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}$")
 	@Column(nullable = false)
 	private String email;
 
+	@Column(nullable = false)
 	private String nickname;
+
+	@Column(nullable = false)
+	private String gender;
+
+	@Column(nullable = false)
+	private String age;
 
 	@Pattern(regexp = "^[0-9]{3}-[0-9]{4}-[0-9]{4}$", message = "올바르지 않은 핸드폰 번호 형식입니다.")
 	private String phone;
@@ -91,9 +86,12 @@ public class Users extends BaseTimeEntity {
 	private List<Portfolios> portfoliosList;
 
 	@Builder
-	public Users(String email, String nickname, Files profileImage, AuthProvider authProvider, String authProviderId) {
+	public Users(String email, String nickname, String gender, String age,
+				 Files profileImage, AuthProvider authProvider, String authProviderId) {
 		this.email = email;
 		this.nickname = nickname;
+		this.gender = gender;
+		this.age = age;
 		this.profileImage = profileImage;
 		this.authProvider = authProvider;
 		this.authProviderId = authProviderId;
@@ -137,6 +135,10 @@ public class Users extends BaseTimeEntity {
 		if (customers.getUsers() != this) {
 			customers.setUsers(this);
 		}
+	}
+
+	public void setAccountStatusToNotEligible() {
+		this.accountStatus = UserAccountStatusEnum.NON_ELIGIBLE;
 	}
 
 	public void createPhone(String phone) {

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/enums/UserAccountStatusEnum.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/domain/users/enums/UserAccountStatusEnum.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Getter
 public enum UserAccountStatusEnum {
 	NORMAL("정상"),
+	NON_ELIGIBLE("비대상"),
 	SUSPENDED("정지"),
 	WITHDRAW("탈퇴"),
 	BANNED("재가입불가");

--- a/src/main/java/swmaestro/spaceodyssey/weddingmate/global/constant/ResponseConstant.java
+++ b/src/main/java/swmaestro/spaceodyssey/weddingmate/global/constant/ResponseConstant.java
@@ -23,10 +23,12 @@ public class ResponseConstant {
 
 	public static final String ACCOUNT_SUSPENDED_MESSAGE = "정지된 계정입니다.";
 	public static final String ACCOUNT_WITHDRAW_MESSAGE = "이미 탈퇴한 계정입니다.";
-	public static final String ACCOUNT_BANNED_MESSAGE = "재가입 불가능한 계정입니다.";
+	public static final String ACCOUNT_BANNED_MESSAGE = "영구 정지된 계정입니다.";
+	public static final String ACCOUNT_NON_ELIGIBLE_MESSAGE = "서비스 대상이 아닌 계정입니다.";
 
 	// exception
 	public static final String USER_NOTFOUND = "해당 유저를 찾을 수 없습니다.";
+	public static final String USER_NOT_TARGET = "가입 대상자가 아닙니다.";
 	public static final String USER_NAME_NOTFOUND = "해당 유저의 이름을 찾을 수 없습니다(CustomUserDetailsService)";
 	public static final String USER_UNAUTHORIZED = "권한이 없는 유저입니다";
 	public static final String PLANNER_NOTFOUND = "해당 플래너를 찾을 수 없습니다.";
@@ -40,6 +42,8 @@ public class ResponseConstant {
 	public static final String OAUTH_PROVIDERID_NOTFOUND = "OAuth2 Provider에서 ProviderId을 찾을 수 없습니다.";
 	public static final String OAUTH_DUPLICATE_EMAIL = "회원가입을 통해 이미 가입하였습니다. 해당 SNS 계정으로 다시 시도해주세요.";
 	public static final String OAUTH_UNAUTHORIZED_URL = "해당 url은 인증되지 않았습니다.";
+	public static final String OAUTH_GENDER_NOT_PROVIDED = "성별 미제공";
+	public static final String OAUTH_AGE_NOT_PROVIDED = "연령 미제공";
 
 	/* PROFILE */
 	public static final String PROFILE_MODIFICATION_NOT_ALLOWED = "해당 프로필의 작성자가 아닙니다.";


### PR DESCRIPTION
### 작업 개요
악성 유저를 거르기 위해 카카오 회원가입 및 로그인 시 gender와 age로 검증

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->

### 작업 상세 내용
![image](https://github.com/SWM-Space-Odyssey/WeddingMate_BackEnd/assets/68282057/7dd9dd54-91c7-4292-b18d-40c798081f5c)
- 악성 유저들의 무분별한 가입을 막기 위해 카카오에서 성별, 연령대를 받아 거르기로 함
- 연령대가 20~29, 30~39가 아닌 경우나 성별, 연령대를 허용하지 않은 경우는 user 상태가 NON_ELIGIBLE로 들어감
- 해당 유저가 로그인을 다시 시도할 경우 프론트엔드에서 해당하는 error page로 redirect되도록 설정
- 기존 유저들의 가입 및 접근을 유지하기 위해 gender와 age는 각각 female, 20~29로 변경함

### 생각해볼 문제
