### PR TITLE
[SO-301] fix: oauth.yml에 성별, 연령대 추가

### DIFF
--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -13,6 +13,8 @@ spring:
               - profile_nickname
               - profile_image
               - account_email
+              - gender
+              - age_range
             client-authentication-method: client_secret_post
             client-name: kakao
         provider:


### PR DESCRIPTION
### 작업 개요
카카오 인가 코드 요청 과정에서 성별, 연령대 요청하도록 설정

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->

### 작업 상세 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->

### 생각해볼 문제
<!--
  ex) 
  1. wav 파일을 매번 입력하기 귀찮겠다.
-->